### PR TITLE
Fix CounterLimit lost-update race that hangs Asyncc.Parallel under sustained load

### DIFF
--- a/src/main/java/org/ores/async/CounterLimit.java
+++ b/src/main/java/org/ores/async/CounterLimit.java
@@ -1,60 +1,85 @@
 package org.ores.async;
 
-/*
- * <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
- **/
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Shared counter used by {@link NeoParallel} / {@link NeoSeries} / {@link NeoQueue} / etc. to
+ * track how many tasks have been started vs finished in a given combinator invocation, and to
+ * answer {@link #isBelowCapacity()} for fan-out scheduling.
+ *
+ * <p>Production-readiness note: before this rewrite, {@code started} and {@code finished} were
+ * plain non-atomic {@code Integer} fields mutated via post-increment {@code ++}. They were read
+ * and incremented from <strong>different</strong> per-task callback threads (each
+ * {@code AsyncTaskRunner} holds its own {@code cbLock} but increments a single shared
+ * {@code CounterLimit}). Under sustained rapid-fire load, one of the increments eventually
+ * gets lost — the resulting {@code finished < started} mismatch makes
+ * {@code ParallelRunner.isDone()} return {@code false} forever, the final callback never fires,
+ * and the caller's {@code CompletableFuture.get(timeout)} times out.
+ *
+ * <p>The fix is to make all counter mutations atomic. {@link AtomicInteger} also doubles as a
+ * memory-visibility barrier so callers reading {@link #getStartedCount()} /
+ * {@link #getFinishedCount()} from other threads see a consistent view without needing the
+ * surrounding {@code synchronized} blocks that several combinators wrap counter access in.
+ * Those synchronized blocks are retained for the moment (removing them would touch nine call
+ * sites and we want this fix small) but they are now redundant for visibility.
+ */
 class CounterLimit {
-  
-  private Integer limit;
-  private Integer started = 0;
-  private Integer finished = 0;
-  private Integer timesTotal = null;
-  
+
+  private volatile Integer limit;
+  private final AtomicInteger started = new AtomicInteger(0);
+  private final AtomicInteger finished = new AtomicInteger(0);
+  private volatile Integer timesTotal = null;
+
   public CounterLimit(Integer limit) {
     this.limit = limit;
   }
-  
+
   public CounterLimit(Integer limit, Integer max) {
     this.limit = limit;
     this.timesTotal = max;
   }
-  
+
   Integer getConcurrency() {
     return this.limit;
   }
-  
+
   Integer setConcurrency(Integer val) {
     return this.limit = val;
   }
-  
+
   void incrementStarted() {
-    this.started++;
+    this.started.incrementAndGet();
   }
-  
+
   void incrementFinished() {
-    this.finished++;
+    this.finished.incrementAndGet();
   }
-  
+
   int getStartedCount() {
-    return this.started;
+    return this.started.get();
   }
-  
+
   int getFinishedCount() {
-    return this.finished;
+    return this.finished.get();
   }
-  
+
   boolean isBelowCapacity() {
-    return this.limit > (this.started - this.finished);
+    // Single snapshot of both counters per call — slightly safer than reading started then
+    // finished as independent volatile reads. For an upper-bound check, the worst case is
+    // a stale-by-one result, which the caller already tolerates.
+    final int s = this.started.get();
+    final int f = this.finished.get();
+    return this.limit > (s - f);
   }
-  
+
   boolean isIdle() {
-    return this.finished >= this.started;
+    return this.finished.get() >= this.started.get();
   }
-  
+
   public Integer getTimesTotal() {
     return this.timesTotal;
   }
-  
+
   public Integer setTimesTotal(Integer max) {
     return this.timesTotal = max;
   }

--- a/src/test/java/general/CounterLimitRaceTest.java
+++ b/src/test/java/general/CounterLimitRaceTest.java
@@ -1,0 +1,127 @@
+package general;
+
+import org.junit.Assume;
+import org.junit.Test;
+import org.ores.async.Asyncc;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Reproducer for a {@code CounterLimit} data race surfaced by running {@code Asyncc.Parallel}
+ * rapid-fire against a virtual-thread executor on JDK 21+.
+ *
+ * <p><strong>Symptom:</strong> {@code Asyncc.Parallel(2 tasks, callback)} eventually fails to
+ * fire its final callback after some number of healthy iterations (observed: ~30-130 in
+ * downstream benchmark harnesses). The caller's {@code CompletableFuture.get(timeout)} hits
+ * its deadline; no exception is thrown by the library itself; the work appears to be lost.
+ *
+ * <p><strong>Cause:</strong> {@code CounterLimit.finished} (and {@code started}) used to be
+ * plain {@code Integer} fields mutated via {@code this.finished++} from per-task callbacks.
+ * Each {@code NeoParallel.AsyncTaskRunner} holds its own {@code cbLock}, so two parallel
+ * tasks could both be inside their {@code synchronized(this.cbLock)} blocks at the same
+ * time, both calling {@code p.c.incrementFinished()} against the <em>shared</em>
+ * {@code CounterLimit}. The post-increment is a read-modify-write on a non-atomic field;
+ * under contention one of the increments gets lost. After the lost increment,
+ * {@code finished &lt; started} forever, so {@code ParallelRunner.isDone()} returns
+ * {@code false} forever, the final callback never fires, and the future hangs.
+ *
+ * <p>The investigation was originally labelled "VT pinning" because virtual threads are
+ * what surfaced it under sustained load. The actual bug is a textbook lost-update data race
+ * — virtual threads just amplify concurrency enough to make it reliably reproducible.
+ *
+ * <p>The fix is in {@code CounterLimit.java} — switch {@code started}/{@code finished} to
+ * {@link java.util.concurrent.atomic.AtomicInteger}.
+ */
+public class CounterLimitRaceTest {
+
+  /**
+   * 500 sequential {@code Asyncc.Parallel} calls, two tasks each, each task sleeps ~2ms. On
+   * the fixed (post-AtomicInteger) implementation this completes in ~400ms; pre-fix master
+   * times out by iteration 40-130 with the lost-update symptom described in the class
+   * javadoc.
+   */
+  @Test(timeout = 60_000)
+  public void parallelDoesNotLoseFinalCallbackUnderRapidFire() throws Exception {
+
+    // The library targets JDK 11; only run this test when a JDK 21+ runtime gives us
+    // virtual threads. Reflection because `Executors.newVirtualThreadPerTaskExecutor()` is
+    // not available in the JDK 11 baseline `release` the maven-compiler-plugin enforces.
+    final ExecutorService vt = newVirtualThreadPerTaskExecutorOrSkip();
+    final int iterations = 500;
+    try {
+      for (int i = 0; i < iterations; i++) {
+
+        final CompletableFuture<Integer> result = new CompletableFuture<>();
+        final int iter = i;
+
+        final AtomicInteger counter = new AtomicInteger();
+        final List<Asyncc.AsyncTask<String, Throwable>> tasks = List.of(
+            cb -> vt.submit(() -> {
+              try {
+                Thread.sleep(2);
+                cb.done(null, "A");
+              } catch (Throwable t) {
+                cb.done(t, null);
+              }
+            }),
+            cb -> vt.submit(() -> {
+              try {
+                Thread.sleep(2);
+                cb.done(null, "B");
+              } catch (Throwable t) {
+                cb.done(t, null);
+              }
+            }));
+
+        Asyncc.Parallel(tasks, (err, results) -> {
+          if (err != null) {
+            result.completeExceptionally(unwrap(err));
+            return;
+          }
+          counter.incrementAndGet();
+          result.complete(results.size());
+        });
+
+        try {
+          final Integer got = result.get(5, TimeUnit.SECONDS);
+          if (got == null || got != 2) {
+            throw new AssertionError("iter=" + iter + " got=" + got);
+          }
+        } catch (java.util.concurrent.TimeoutException te) {
+          throw new AssertionError("Asyncc.Parallel timed out at iteration " + iter
+              + ". Cause: CounterLimit.{started,finished} non-atomic increment lost an"
+              + " update; isDone() now returns false forever and the final callback"
+              + " never fires. Make those fields AtomicInteger.", te);
+        }
+      }
+    } finally {
+      vt.shutdown();
+      vt.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static Throwable unwrap(final Object err) {
+    if (err instanceof Throwable) {
+      return (Throwable) err;
+    }
+    return new RuntimeException(String.valueOf(err));
+  }
+
+  private static ExecutorService newVirtualThreadPerTaskExecutorOrSkip() {
+    try {
+      final Method m = Executors.class.getMethod("newVirtualThreadPerTaskExecutor");
+      return (ExecutorService) m.invoke(null);
+    } catch (NoSuchMethodException pre21) {
+      Assume.assumeTrue("requires JDK 21+ for virtual threads", false);
+      throw new AssertionError("unreachable");
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`CounterLimit.started` and `CounterLimit.finished` were plain `Integer` fields
mutated with non-atomic `this.started++` / `this.finished++` from per-task
callback threads. Under sustained concurrent load (most reliably reproducible
with a virtual-thread executor on JDK 21+), one of the increments gets lost,
and the combinator's `isDone()` returns `false` forever — the final callback
never fires.

This is a textbook lost-update data race. Fixing it is a two-line change.

## Why it took so long to surface

The race needs two per-task callbacks to enter their `synchronized(cbLock)`
blocks simultaneously. Each `AsyncTaskRunner` has its **own** `cbLock` (not
shared), so the synchronized blocks don't serialise the
`p.c.incrementFinished()` calls — they only protect each runner's own state.
Two parallel-task callbacks finishing nearly together both call
`incrementFinished()` on the **shared** `CounterLimit` without
synchronisation.

With platform threads, the contention window between the two `cbLock`
sections is narrow enough that the race is rare. With virtual threads on
JDK 21+, concurrency is amplified and the race surfaces within
30 - 130 iterations of a tight Asyncc.Parallel loop, every time.

## How it was misdiagnosed first

The downstream consumer that surfaced this
([dd-akka-ws-server's benchmark vs Akka Streams](https://github.com/ORESoftware/k8s-cluster/blob/dev/remote/akka-ws-server/readme.md))
initially labelled it a "JDK 21 virtual-thread pinning" issue caused by the
`synchronized` accessors added to `ShortCircuit` in #8. That hypothesis was
**wrong**:

- `-Djdk.tracePinnedThreads=full` produced no pinning output.
- The symptom (timeout in `CompletableFuture.get`) traces back to a data race
  that pre-existed #8 entirely.

The class name `CounterLimitRaceTest` reflects the actual cause; the
misdiagnosis is documented in the class javadoc so future readers grepping
for "VT pinning" land on the right explanation.

## Fix

`CounterLimit.{started, finished}` → `AtomicInteger`. `incrementAndGet()`
on every mutation, plain `get()` on every read. `limit` and `timesTotal`
become `volatile` for memory visibility (they're only written from
configuration setters, never concurrently incremented, so they don't need
the full atomic API).

The public surface of `CounterLimit` (a package-private class) is unchanged:
all callers stay source-compatible.

## Tests

### New reproducer: `general.CounterLimitRaceTest`

500 sequential `Asyncc.Parallel(2 tasks, callback)` invocations against a
`newVirtualThreadPerTaskExecutor()` executor. Each task sleeps 2ms then
calls `cb.done(null, value)`.

- Pre-fix `master`: times out at iteration 30 - 130, every run.
- This commit: completes in ~400ms reliably across many runs.

Reflectively probes for `Executors.newVirtualThreadPerTaskExecutor` and
`Assume`-skips on pre-JDK-21 runtimes, so the project's JDK 11 release
floor stays compatible.

### Existing suite

- JDK 17: 71/71 pass + new test cleanly skipped
- JDK 21: 72/72 pass

## Coverage

Every combinator that uses `CounterLimit` benefits from the fix without
needing source changes: `Parallel`, `Series`, `Map`, `Each`, `Reduce`,
`Times`, `Concat`, `FilterMap`, `Whilst`, `Waterfall`, `Inject`, `Race`,
`GroupBy`, `Queue`. The current test suite covers most of these, but only
this PR's new test stresses them hard enough to surface the race; rolling
similar rapid-fire tests for the other combinators is a follow-up.

## Test plan

- [x] `mvn -B test` on JDK 17 — 71/71 (CounterLimitRaceTest skipped)
- [x] `mvn -B test` on JDK 21 — 72/72
- [x] 500-iter reproducer goes from "TimeoutException at iter ~32" to "0.4s clean pass"
- [ ] (Post-merge) `dd-akka-ws-server` benchmark harness uncaps its iteration
  count (currently hard-pinned at 30 to dodge this bug) and re-runs against
  JitPack-built master.

Made with [Cursor](https://cursor.com)