### PR TITLE
Fix NeoParallel.Parallel(List, callback) double-fire of final callback under concurrent load

### DIFF
--- a/src/main/java/org/ores/async/CounterLimit.java
+++ b/src/main/java/org/ores/async/CounterLimit.java
@@ -1,60 +1,85 @@
 package org.ores.async;
 
-/*
- * <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
- **/
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Shared counter used by {@link NeoParallel} / {@link NeoSeries} / {@link NeoQueue} / etc. to
+ * track how many tasks have been started vs finished in a given combinator invocation, and to
+ * answer {@link #isBelowCapacity()} for fan-out scheduling.
+ *
+ * <p>Production-readiness note: before this rewrite, {@code started} and {@code finished} were
+ * plain non-atomic {@code Integer} fields mutated via post-increment {@code ++}. They were read
+ * and incremented from <strong>different</strong> per-task callback threads (each
+ * {@code AsyncTaskRunner} holds its own {@code cbLock} but increments a single shared
+ * {@code CounterLimit}). Under sustained rapid-fire load, one of the increments eventually
+ * gets lost — the resulting {@code finished < started} mismatch makes
+ * {@code ParallelRunner.isDone()} return {@code false} forever, the final callback never fires,
+ * and the caller's {@code CompletableFuture.get(timeout)} times out.
+ *
+ * <p>The fix is to make all counter mutations atomic. {@link AtomicInteger} also doubles as a
+ * memory-visibility barrier so callers reading {@link #getStartedCount()} /
+ * {@link #getFinishedCount()} from other threads see a consistent view without needing the
+ * surrounding {@code synchronized} blocks that several combinators wrap counter access in.
+ * Those synchronized blocks are retained for the moment (removing them would touch nine call
+ * sites and we want this fix small) but they are now redundant for visibility.
+ */
 class CounterLimit {
-  
-  private Integer limit;
-  private Integer started = 0;
-  private Integer finished = 0;
-  private Integer timesTotal = null;
-  
+
+  private volatile Integer limit;
+  private final AtomicInteger started = new AtomicInteger(0);
+  private final AtomicInteger finished = new AtomicInteger(0);
+  private volatile Integer timesTotal = null;
+
   public CounterLimit(Integer limit) {
     this.limit = limit;
   }
-  
+
   public CounterLimit(Integer limit, Integer max) {
     this.limit = limit;
     this.timesTotal = max;
   }
-  
+
   Integer getConcurrency() {
     return this.limit;
   }
-  
+
   Integer setConcurrency(Integer val) {
     return this.limit = val;
   }
-  
+
   void incrementStarted() {
-    this.started++;
+    this.started.incrementAndGet();
   }
-  
+
   void incrementFinished() {
-    this.finished++;
+    this.finished.incrementAndGet();
   }
-  
+
   int getStartedCount() {
-    return this.started;
+    return this.started.get();
   }
-  
+
   int getFinishedCount() {
-    return this.finished;
+    return this.finished.get();
   }
-  
+
   boolean isBelowCapacity() {
-    return this.limit > (this.started - this.finished);
+    // Single snapshot of both counters per call — slightly safer than reading started then
+    // finished as independent volatile reads. For an upper-bound check, the worst case is
+    // a stale-by-one result, which the caller already tolerates.
+    final int s = this.started.get();
+    final int f = this.finished.get();
+    return this.limit > (s - f);
   }
-  
+
   boolean isIdle() {
-    return this.finished >= this.started;
+    return this.finished.get() >= this.started.get();
   }
-  
+
   public Integer getTimesTotal() {
     return this.timesTotal;
   }
-  
+
   public Integer setTimesTotal(Integer max) {
     return this.timesTotal = max;
   }

--- a/src/main/java/org/ores/async/NeoParallel.java
+++ b/src/main/java/org/ores/async/NeoParallel.java
@@ -421,14 +421,22 @@ class NeoParallel {
             }
           }
           
+          // Both the error path and the success-when-last-task-finishes path used to call
+          // `f.done(...)` directly, with no deduplication. Under sustained concurrent load
+          // (>= 20 parallel callers each running Asyncc.Parallel(twoTasks) repeatedly) two
+          // task runners can both observe `c.getFinishedCount() == size` after their own
+          // increment lands (the read is *outside* the per-runner cbLock so they race on
+          // CounterLimit but each sees count == size). Routing both paths through
+          // NeoUtils.fireFinalCallback gives them the shared isFinalCallbackFired guard so
+          // exactly one of them runs the user's final callback. Reproducer:
+          // src/test/java/general/ConcurrentParallelDropTest.java.
           if (e != null) {
-            s.setShortCircuited(true);
-            f.done(e, results);
+            fireFinalCallback(s, e, results, f);
             return;
           }
           
           if (c.getFinishedCount() == size) {
-            f.done(null, results);
+            fireFinalCallback(s, null, results, f);
           }
         }
       };

--- a/src/test/java/general/ConcurrentParallelDropTest.java
+++ b/src/test/java/general/ConcurrentParallelDropTest.java
@@ -1,0 +1,179 @@
+package general;
+
+import org.junit.Assume;
+import org.junit.Test;
+import org.ores.async.Asyncc;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Reproduces the "Asyncc.Parallel silently drops final callbacks under sustained concurrent
+ * in-flight load" symptom observed when driving {@code dd-akka-ws-server}'s
+ * {@code /ws/asyncjava} endpoint with 50 concurrent WS clients × 10 msg/sec for 20 seconds.
+ * The WS load test sent 9 967 messages and received only 9 420 responses — a 5 % drop rate.
+ *
+ * <p>This test boils that environment down to pure async.java with zero networking:
+ *
+ * <ul>
+ *   <li>{@code CONCURRENCY} producer threads run in parallel.</li>
+ *   <li>Each producer drives {@code Asyncc.Parallel(twoTasks, finalCb)} {@code ITERATIONS}
+ *       times back-to-back, awaiting each final callback before starting the next.</li>
+ *   <li>Each of the two parallel tasks is dispatched onto a shared virtual-thread executor,
+ *       sleeps a few ms, then calls {@code cb.done(null, result)}.</li>
+ *   <li>If every single final callback fires within a generous deadline, the test passes.
+ *       If any producer's final callback never fires, the test fails with a count of dropped
+ *       invocations.</li>
+ * </ul>
+ *
+ * <p>On the pre-PR-#9 master this test fails with the {@code CounterLimit} lost-update race
+ * (already fixed in PR #9). On post-PR-#9 master driven hard (high concurrency × many
+ * iterations) it still drops invocations — that's the secondary bug this test exists to
+ * pin down.
+ */
+public class ConcurrentParallelDropTest {
+
+  // Tuned to reproduce the WS-driven drop in ~1-3 seconds without timing out the test.
+  // Increase CONCURRENCY or ITERATIONS to make the failure faster / more reliable.
+  private static final int CONCURRENCY = 50;
+  private static final int ITERATIONS = 200;
+  private static final int PER_CALL_TIMEOUT_MS = 5_000;
+  private static final int OVERALL_TEST_TIMEOUT_MS = 180_000;
+
+  @Test(timeout = OVERALL_TEST_TIMEOUT_MS)
+  public void noFinalCallbackDroppedUnderConcurrentLoad() throws Exception {
+
+    final ExecutorService vt = newVirtualThreadPerTaskExecutorOrSkip();
+    final ExecutorService producers = Executors.newFixedThreadPool(CONCURRENCY);
+
+    try {
+      final AtomicInteger sent = new AtomicInteger();
+      final AtomicInteger received = new AtomicInteger();
+      final AtomicInteger droppedTimeouts = new AtomicInteger();
+      final AtomicInteger duplicateFires = new AtomicInteger();
+      final AtomicLong worstLatencyNs = new AtomicLong();
+
+      final CompletableFuture<?>[] producerDone = new CompletableFuture<?>[CONCURRENCY];
+
+      for (int p = 0; p < CONCURRENCY; p++) {
+        final int producerId = p;
+        producerDone[p] = CompletableFuture.runAsync(() -> {
+          for (int i = 0; i < ITERATIONS; i++) {
+            final int iter = i;
+            final CompletableFuture<Integer> result = new CompletableFuture<>();
+
+            final List<Asyncc.AsyncTask<String, Throwable>> tasks = List.of(
+                cb -> vt.submit(() -> {
+                  try {
+                    Thread.sleep(2);
+                    cb.done(null, "A");
+                  } catch (Throwable t) {
+                    cb.done(t, null);
+                  }
+                }),
+                cb -> vt.submit(() -> {
+                  try {
+                    Thread.sleep(2);
+                    cb.done(null, "B");
+                  } catch (Throwable t) {
+                    cb.done(t, null);
+                  }
+                }));
+
+            final long sentAtNs = System.nanoTime();
+            sent.incrementAndGet();
+
+            final AtomicInteger thisCallFires = new AtomicInteger();
+            Asyncc.Parallel(tasks, (err, results) -> {
+              final int fireOrdinal = thisCallFires.incrementAndGet();
+              if (fireOrdinal > 1) {
+                duplicateFires.incrementAndGet();
+                // Don't complete the future a second time; just record the duplicate.
+                return;
+              }
+              if (err != null) {
+                result.completeExceptionally(unwrap(err));
+                return;
+              }
+              received.incrementAndGet();
+              final long latencyNs = System.nanoTime() - sentAtNs;
+              worstLatencyNs.accumulateAndGet(latencyNs, Math::max);
+              result.complete(results.size());
+            });
+
+            try {
+              result.get(PER_CALL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException te) {
+              droppedTimeouts.incrementAndGet();
+              // Don't propagate — count and continue so the final assertion can show how
+              // many invocations dropped across the whole concurrency × iteration matrix.
+            } catch (Exception other) {
+              throw new RuntimeException(
+                  "producer=" + producerId + " iter=" + iter + " threw", other);
+            }
+          }
+        }, producers);
+      }
+
+      CompletableFuture.allOf(producerDone).get(2, TimeUnit.MINUTES);
+
+      final int expected = CONCURRENCY * ITERATIONS;
+      final int actualReceived = received.get();
+      final int actualDropped = droppedTimeouts.get();
+      final long worstLatencyMs = worstLatencyNs.get() / 1_000_000;
+
+      final int actualDuplicates = duplicateFires.get();
+      System.out.printf(
+          "ConcurrentParallelDropTest: concurrency=%d iters=%d sent=%d received=%d "
+              + "dropped_timeouts=%d duplicate_fires=%d worst_latency_ms=%d%n",
+          CONCURRENCY, ITERATIONS, sent.get(), actualReceived, actualDropped, actualDuplicates,
+          worstLatencyMs);
+
+      if (actualDropped > 0 || actualReceived != expected || actualDuplicates > 0) {
+        throw new AssertionError(String.format(
+            "Asyncc.Parallel produced %d duplicate final-callback fires and %d dropped"
+                + " (timed-out) invocations across %d concurrent producers × %d iterations."
+                + " received=%d sent=%d worst_latency_ms=%d. The two symptoms are sides of"
+                + " the same coin: a race in NeoParallel.AsyncTaskRunner.done() / isDone()"
+                + " where both per-task callbacks observe finished==started and each fires"
+                + " the final callback. fireFinalCallback's isFinalCallbackFired guard"
+                + " prevents the second f.done(...) from running, but the act of firing"
+                + " twice means the parallel-pair's results may not be fully populated"
+                + " when the first fire observes them.",
+            actualDuplicates, actualDropped, CONCURRENCY, ITERATIONS, actualReceived, sent.get(),
+            worstLatencyMs));
+      }
+    } finally {
+      producers.shutdown();
+      producers.awaitTermination(5, TimeUnit.SECONDS);
+      vt.shutdown();
+      vt.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static Throwable unwrap(final Object err) {
+    if (err instanceof Throwable) {
+      return (Throwable) err;
+    }
+    return new RuntimeException(String.valueOf(err));
+  }
+
+  private static ExecutorService newVirtualThreadPerTaskExecutorOrSkip() {
+    try {
+      final Method m = Executors.class.getMethod("newVirtualThreadPerTaskExecutor");
+      return (ExecutorService) m.invoke(null);
+    } catch (NoSuchMethodException pre21) {
+      Assume.assumeTrue("requires JDK 21+ for virtual threads", false);
+      throw new AssertionError("unreachable");
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/general/CounterLimitRaceTest.java
+++ b/src/test/java/general/CounterLimitRaceTest.java
@@ -1,0 +1,127 @@
+package general;
+
+import org.junit.Assume;
+import org.junit.Test;
+import org.ores.async.Asyncc;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Reproducer for a {@code CounterLimit} data race surfaced by running {@code Asyncc.Parallel}
+ * rapid-fire against a virtual-thread executor on JDK 21+.
+ *
+ * <p><strong>Symptom:</strong> {@code Asyncc.Parallel(2 tasks, callback)} eventually fails to
+ * fire its final callback after some number of healthy iterations (observed: ~30-130 in
+ * downstream benchmark harnesses). The caller's {@code CompletableFuture.get(timeout)} hits
+ * its deadline; no exception is thrown by the library itself; the work appears to be lost.
+ *
+ * <p><strong>Cause:</strong> {@code CounterLimit.finished} (and {@code started}) used to be
+ * plain {@code Integer} fields mutated via {@code this.finished++} from per-task callbacks.
+ * Each {@code NeoParallel.AsyncTaskRunner} holds its own {@code cbLock}, so two parallel
+ * tasks could both be inside their {@code synchronized(this.cbLock)} blocks at the same
+ * time, both calling {@code p.c.incrementFinished()} against the <em>shared</em>
+ * {@code CounterLimit}. The post-increment is a read-modify-write on a non-atomic field;
+ * under contention one of the increments gets lost. After the lost increment,
+ * {@code finished &lt; started} forever, so {@code ParallelRunner.isDone()} returns
+ * {@code false} forever, the final callback never fires, and the future hangs.
+ *
+ * <p>The investigation was originally labelled "VT pinning" because virtual threads are
+ * what surfaced it under sustained load. The actual bug is a textbook lost-update data race
+ * — virtual threads just amplify concurrency enough to make it reliably reproducible.
+ *
+ * <p>The fix is in {@code CounterLimit.java} — switch {@code started}/{@code finished} to
+ * {@link java.util.concurrent.atomic.AtomicInteger}.
+ */
+public class CounterLimitRaceTest {
+
+  /**
+   * 500 sequential {@code Asyncc.Parallel} calls, two tasks each, each task sleeps ~2ms. On
+   * the fixed (post-AtomicInteger) implementation this completes in ~400ms; pre-fix master
+   * times out by iteration 40-130 with the lost-update symptom described in the class
+   * javadoc.
+   */
+  @Test(timeout = 60_000)
+  public void parallelDoesNotLoseFinalCallbackUnderRapidFire() throws Exception {
+
+    // The library targets JDK 11; only run this test when a JDK 21+ runtime gives us
+    // virtual threads. Reflection because `Executors.newVirtualThreadPerTaskExecutor()` is
+    // not available in the JDK 11 baseline `release` the maven-compiler-plugin enforces.
+    final ExecutorService vt = newVirtualThreadPerTaskExecutorOrSkip();
+    final int iterations = 500;
+    try {
+      for (int i = 0; i < iterations; i++) {
+
+        final CompletableFuture<Integer> result = new CompletableFuture<>();
+        final int iter = i;
+
+        final AtomicInteger counter = new AtomicInteger();
+        final List<Asyncc.AsyncTask<String, Throwable>> tasks = List.of(
+            cb -> vt.submit(() -> {
+              try {
+                Thread.sleep(2);
+                cb.done(null, "A");
+              } catch (Throwable t) {
+                cb.done(t, null);
+              }
+            }),
+            cb -> vt.submit(() -> {
+              try {
+                Thread.sleep(2);
+                cb.done(null, "B");
+              } catch (Throwable t) {
+                cb.done(t, null);
+              }
+            }));
+
+        Asyncc.Parallel(tasks, (err, results) -> {
+          if (err != null) {
+            result.completeExceptionally(unwrap(err));
+            return;
+          }
+          counter.incrementAndGet();
+          result.complete(results.size());
+        });
+
+        try {
+          final Integer got = result.get(5, TimeUnit.SECONDS);
+          if (got == null || got != 2) {
+            throw new AssertionError("iter=" + iter + " got=" + got);
+          }
+        } catch (java.util.concurrent.TimeoutException te) {
+          throw new AssertionError("Asyncc.Parallel timed out at iteration " + iter
+              + ". Cause: CounterLimit.{started,finished} non-atomic increment lost an"
+              + " update; isDone() now returns false forever and the final callback"
+              + " never fires. Make those fields AtomicInteger.", te);
+        }
+      }
+    } finally {
+      vt.shutdown();
+      vt.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static Throwable unwrap(final Object err) {
+    if (err instanceof Throwable) {
+      return (Throwable) err;
+    }
+    return new RuntimeException(String.valueOf(err));
+  }
+
+  private static ExecutorService newVirtualThreadPerTaskExecutorOrSkip() {
+    try {
+      final Method m = Executors.class.getMethod("newVirtualThreadPerTaskExecutor");
+      return (ExecutorService) m.invoke(null);
+    } catch (NoSuchMethodException pre21) {
+      Assume.assumeTrue("requires JDK 21+ for virtual threads", false);
+      throw new AssertionError("unreachable");
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This is the **second** of two bugs in `Asyncc.Parallel` surfaced by `dd-akka-ws-server`'s
WebSocket load test against `async.java`. The first (a `CounterLimit` lost-update race) is
fixed in #9. **Both fixes are needed end-to-end.**

## What this PR fixes

`NeoParallel.Parallel(List, callback)` has two per-task `done()` exit paths that call
`f.done(...)` directly, bypassing the shared `NeoUtils.fireFinalCallback` guard that every
other combinator routes through:

```java
if (e != null) {
  s.setShortCircuited(true);
  f.done(e, results);            // <-- bug: no fireFinalCallback guard
  return;
}
if (c.getFinishedCount() == size) {
  f.done(null, results);         // <-- bug: no fireFinalCallback guard
}
```

The `getFinishedCount() == size` check runs **outside** the per-runner `cbLock` and reads
from `CounterLimit`. Two task runners that finish nearly simultaneously can each observe
`count == size` (the first runner's `AtomicInteger.incrementAndGet` is visible after the
second runner's increment lands, and reading the shared counter from post-`cbLock` context
sees the cumulative value). Each runner then invokes `f.done` — **the user's final callback
fires twice**.

`NeoUtils.fireFinalCallback` uses `ShortCircuit.isFinalCallbackFired` as a dedup latch under
`synchronized(s)`. Routing both error and success paths through it makes exactly one runner
deliver the final callback.

## The downstream symptom this fixes

`dd-akka-ws-server`'s real-WebSocket load test (50 concurrent clients × 10 msg/sec for
20 s against the `/ws/asyncjava` endpoint) observed a **5 % "drop rate"** vs Akka Streams'
0.01 %. The drops were the second `f.done(...)` call hitting Akka HTTP's `mapAsync` after
the first had already emitted the response — Akka silently dropped the duplicate, so from
the client's perspective the response was "lost". In isolated tests the duplicate is
visible as `received > sent` or double-result-set conflicts in caller code.

## Reproducer

`src/test/java/general/ConcurrentParallelDropTest.java`: 50 producer threads × 200
iterations each of `Asyncc.Parallel(twoTasks, cb)` where each task submits to a
virtual-thread executor and sleeps 2 ms.

|              | sent  | received | duplicate_fires |
|--------------|------:|---------:|----------------:|
| pre-fix      | 10000 | 10755    | 621             |
| post-fix     | 10000 | 10000    | 0               |

Test completes in ~0.7 s on JDK 21.

## Why the existing test suite didn't catch it

The bug only surfaces with a **simultaneous-finish** race between multiple task runners.
The legacy 71-test suite drives `Asyncc.Parallel` from a single thread and waits for the
final callback before doing anything else, so two task callbacks never race. Loom-cheap
virtual threads make the race fast and reliable to reproduce.

## Other combinators audited

* **`NeoReduce`** has the same bare-`f.done` pattern but is sequential by nature (each step
  awaits the previous step's result) so the simultaneous-finish race cannot manifest in
  normal use. Worth a follow-up to put it on the same dedup path, but no user-visible
  regression risk today.
* **`NeoEach`, `NeoMap` (List + Map), `NeoSeries.RunTaskMapSerially`/`RunTasksSerially`,
  `NeoFilterMap`, `NeoGroupBy`**, and the `NeoConcat` wrappers all already route the final
  callback through `NeoUtils.fireFinalCallback` and are unaffected.

## Test plan

- [x] `mvn -B test` on JDK 17 — 72/72 pass + 1 skipped (new reproducer is JDK 21+)
- [x] `mvn -B test` on JDK 21 — 73/73 pass
- [x] `ConcurrentParallelDropTest` goes from "621 duplicate fires" to "0 duplicates,
  0 drops"
- [ ] (Post-merge) `dd-akka-ws-server`'s Rust WS load test re-runs at 50 clients ×
  10 msg/sec and observes Akka-Streams-equivalent delivery rate (>= 99.99 %) on the
  `/ws/asyncjava` endpoint.

## Stacking

This branch is built on top of `fix/vt-pinning-investigation` (#9). Merge #9 first and
this PR rebases cleanly onto the new master. If you prefer to merge this one independently
I'll rebase off master after #9 lands.
