### PR TITLE
[codex] Modernize Future and Loom interop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         jdk: ['17', '21']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.jdk }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,19 @@
 name: release
 
-# Triggered by pushing a `v*` tag (e.g. `v0.2.0`). The tag must match the
+# Triggered by pushing a `v*` tag (e.g. `v0.2.10`). The tag must match the
 # `<version>` in pom.xml (minus the leading `v`). Maintainers cut a release like
 # this:
 #
-#   1. Bump `<version>` in pom.xml from `0.2.0-SNAPSHOT` to `0.2.0`, commit.
-#   2. `git tag v0.2.0 && git push --tags`
-#   3. (Optional) Bump pom.xml back to `0.2.1-SNAPSHOT` and commit.
+#   1. Bump `<version>` in pom.xml from `0.2.10-SNAPSHOT` to `0.2.10`, commit.
+#   2. `git tag v0.2.10 && git push --tags`
+#   3. (Optional) Bump pom.xml back to `0.2.11-SNAPSHOT` and commit.
 #
 # The workflow then:
 #   - imports a GPG private key (held in repo secret MAVEN_GPG_PRIVATE_KEY)
 #   - signs all artifacts
 #   - uploads to the Sonatype Central Portal using a User Token
 #     (secrets CENTRAL_USERNAME / CENTRAL_PASSWORD)
+#   - publishes the same version to GitHub Packages using GITHUB_TOKEN
 #   - publishes a GitHub Release with the jar attached
 #
 # Required repo secrets (add at Settings → Secrets and variables → Actions):
@@ -29,16 +30,34 @@ on:
 
 permissions:
   contents: write   # for creating the GitHub Release at the end
+  packages: write   # for publishing to GitHub Packages
 
 jobs:
   publish:
     name: publish to maven central
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Check required Central release secrets
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in CENTRAL_USERNAME CENTRAL_PASSWORD MAVEN_GPG_PRIVATE_KEY MAVEN_GPG_PASSPHRASE; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name repository secret is not configured"
+              missing=1
+            fi
+          done
+          exit "$missing"
 
       - name: Set up JDK 17 + Maven cache + Central credentials
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
@@ -72,10 +91,26 @@ jobs:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-        run: mvn -B -P release -DskipTests deploy
+        run: mvn -B -P publish-artifacts,release -DskipTests deploy
+
+      - name: Set up GitHub Packages credentials
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Deploy to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B -P publish-artifacts,github-packages -DskipTests -Dgpg.skip=true deploy
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,73 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-06-04
+
+### Added
+
+* **Plain JDK `Future` interop.**
+  `WrapFuture.toCompletableFuture(Executor, Future)` and
+  `WrapFuture.fromFuture(Executor, Future)` call `Future.get()` inside the
+  library on a caller-supplied waiting executor, unwrap `ExecutionException`
+  causes, and propagate cancellation from the returned `CompletableFuture`
+  back to the underlying `Future`.
+
+* **Collection helpers for already-started plain futures.**
+  `AsyncFut.ParallelFutures(waitExecutor, futures)` and
+  `AsyncFut.RaceFutures(waitExecutor, futures)` bridge legacy `Future<T>`
+  APIs into the promise-shaped combinators without per-call-site `get()`
+  loops.
+
+* **`AsyncLoom`: Java 21 virtual-thread helpers with a Java 17 bytecode
+  baseline.**
+  The new class detects virtual-thread support reflectively, creates
+  virtual-thread-per-task executors on JDK 21+, and exposes
+  `supply`, `run`, `task`, `installNeoQueueExecutor`, and the blocking
+  combinator family:
+  `ParallelBlocking`, `ParallelLimitBlocking`, `SeriesBlocking`,
+  `RaceBlocking`, `MapBlocking`, `MapLimitBlocking`, `EachBlocking`,
+  `EachLimitBlocking`, `ReduceBlocking`, `TimesBlocking`, `ConcatBlocking`,
+  `ConcatSeriesBlocking`, and `ConcatLimitBlocking`.
+
+* **Callback-style virtual-thread blocking combinators on `Asyncc`.**
+  Added `Asyncc.*Blocking` wrappers for callback users:
+  `ParallelBlocking`, `ParallelLimitBlocking`, `SeriesBlocking`,
+  `RaceBlocking`, `MapBlocking`, `MapLimitBlocking`, `EachBlocking`,
+  `EachLimitBlocking`, `ReduceBlocking`, `TimesBlocking`, `ConcatBlocking`,
+  `ConcatSeriesBlocking`, and `ConcatLimitBlocking`.
+
+* **Future/Loom interop tests.**
+  `FutureAndLoomInteropTest` pins `Future.get()` bridging, cancellation
+  propagation, ordered collection of future results, race semantics, Java
+  17 unsupported-runtime behavior, and JDK 21 virtual-thread execution.
+
+* **Compile-checked examples.**
+  `src/test/java/examples` now includes Future interop, `AsyncLoom` blocking
+  combinator, and callback-style `Asyncc.*Blocking` examples that Maven
+  compiles with the test sources.
+
+### Changed
+
+* **Release/build tooling refreshed.**
+  Upgraded JaCoCo to `0.8.14` so Java 17/21 test runs no longer emit
+  instrumentation errors, pinned Surefire, updated the compiler/jar/source/
+  javadoc/GPG plugin set, and bumped the Sonatype Central Publishing plugin
+  to `0.10.0`.
+
+* **JitPack now downloads Maven 3.9.16.**
+  This keeps JitPack builds compatible with the modern Maven plugin set.
+
+* **GitHub Packages publishing wired into the release workflow.**
+  Added a `github-packages` Maven profile and a release-workflow deploy step
+  using `GITHUB_TOKEN`, separate from the signed Sonatype/Maven Central path.
+
+* **Release credential hygiene.**
+  Replaced the repo-local OSSRH-era `settings.xml` with a safe Central/GitHub
+  Packages template, refreshed the local deploy/GPG helper scripts, and added
+  an explicit release-workflow check for the required Central/GPG secrets.
+
+**Total: 207 tests, 0 failures, 9 JDK21-gated skips on JDK 17.**
+
 ## [0.2.9] - 2026-05-18
 
 ### Fixed
@@ -896,6 +963,8 @@ Initial public release on Maven Central under the
 `com.oresoftware:async.0.1:0.1.1012` coordinate. Frozen — see the new
 `io.github.async-java:async-java` line for active development.
 
-[Unreleased]: https://github.com/async-java/async.java/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/async-java/async.java/compare/v0.2.10...HEAD
+[0.2.10]: https://github.com/async-java/async.java/releases/tag/v0.2.10
+[0.2.9]: https://github.com/async-java/async.java/releases/tag/v0.2.9
 [0.2.0]: https://github.com/async-java/async.java/releases/tag/v0.2.0
 [0.1.1012]: https://repo1.maven.org/maven2/com/oresoftware/async.0.1/0.1.1012/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -822,7 +822,7 @@ run on JDK 11+).
 
 ## [0.2.0] - 2026-05-17
 
-First release under the new `io.github.async-java:async-java` coordinate. The
+First release under the new `io.github.oresoftware:async-java` coordinate. The
 legacy `com.oresoftware:async.0.1:0.1.1012` artifact remains on Maven Central
 indefinitely for existing consumers.
 
@@ -888,10 +888,10 @@ JDK 21 for virtual threads and `Assume`-skip on JDK 11 / 17.
 
 ### Changed
 
-- **Coordinate**: published to `io.github.async-java:async-java` going
-  forward. The `io.github.async-java` namespace is auto-verifiable on the
-  Sonatype Central Portal because the `async-java` GitHub organisation
-  exists at <https://github.com/async-java>.
+- **Coordinate**: published to `io.github.oresoftware:async-java` going
+  forward. The `io.github.oresoftware` namespace is verifiable on the
+  Sonatype Central Portal through the maintainer GitHub account, while the
+  source repository remains at <https://github.com/async-java/async.java>.
 - **Build target**: JDK 10 -> JDK 11 (LTS). The 2.3.2 (2010)
   maven-compiler-plugin upgraded to 3.13.0 with `<release>` so the
   bytecode target is actually honoured on modern JDKs.
@@ -961,7 +961,7 @@ JDK 21 for virtual threads and `Assume`-skip on JDK 11 / 17.
 
 Initial public release on Maven Central under the
 `com.oresoftware:async.0.1:0.1.1012` coordinate. Frozen — see the new
-`io.github.async-java:async-java` line for active development.
+`io.github.oresoftware:async-java` line for active development.
 
 [Unreleased]: https://github.com/async-java/async.java/compare/v0.2.10...HEAD
 [0.2.10]: https://github.com/async-java/async.java/releases/tag/v0.2.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   APIs into the promise-shaped combinators without per-call-site `get()`
   loops.
 
+* **Lazy `CompletionStage` callback tasks.**
+  `WrapFuture.fromStage(Supplier<? extends CompletionStage<V>>)` creates the
+  stage only when an async.java combinator starts that task, preserving
+  `Series`, `ParallelLimit`, and other bounded scheduling semantics.
+
+* **Promise-returning concat helpers.**
+  `AsyncFut.Concat`, `AsyncFut.ConcatSeries`, and `AsyncFut.ConcatLimit` add
+  async map + one-level flatten to the `CompletableFuture` API, matching the
+  callback `Asyncc.Concat*` and virtual-thread `AsyncLoom.Concat*Blocking`
+  families.
+
 * **`AsyncLoom`: Java 21 virtual-thread helpers with a Java 17 bytecode
   baseline.**
   The new class detects virtual-thread support reflectively, creates

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,6 +67,24 @@ In <https://github.com/async-java/async.java/settings/secrets/actions> add:
 | `MAVEN_GPG_PRIVATE_KEY`    | Full contents of `/tmp/maven-gpg-private-key.asc`.           |
 | `MAVEN_GPG_PASSPHRASE`     | Passphrase that unlocks the GPG key.                         |
 
+Or set them from a checked-out repo with:
+
+```bash
+export CENTRAL_USERNAME='...'
+export CENTRAL_PASSWORD='...'
+export MAVEN_GPG_PRIVATE_KEY="$(cat /tmp/maven-gpg-private-key.asc)"
+export MAVEN_GPG_PASSPHRASE='...'
+
+scripts/set-release-secrets.sh
+scripts/check-release-readiness.sh --pre-tag
+```
+
+Use `check-release-readiness.sh --pre-tag` before tagging to catch missing
+GitHub auth, missing repo secrets, and missing local GPG setup. Use
+`check-release-readiness.sh` after the release workflow runs; the post-tag
+check fails until the remote tag exists and Maven Central metadata shows the
+release.
+
 ## Cutting a release (automated path)
 
 ```bash
@@ -74,11 +92,14 @@ In <https://github.com/async-java/async.java/settings/secrets/actions> add:
 #    Edit pom.xml: <version>0.2.10-SNAPSHOT</version> -> <version>0.2.10</version>
 git commit -am "Release 0.2.10"
 
-# 2. Tag the commit. The release workflow only fires on `v*` tags.
+# 2. Confirm release prerequisites before tagging.
+scripts/check-release-readiness.sh --pre-tag
+
+# 3. Tag the commit. The release workflow only fires on `v*` tags.
 git tag v0.2.10
 git push origin master --tags
 
-# 3. (Optional) Open development on the next version.
+# 4. (Optional) Open development on the next version.
 #    Edit pom.xml: <version>0.2.10</version> -> <version>0.2.11-SNAPSHOT</version>
 git commit -am "Begin 0.2.11 development"
 git push

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,9 @@ You need three things to publish to Maven Central:
   * confirm the automatically provisioned GitHub namespace for
     [ORESoftware](https://github.com/ORESoftware), or
   * add a DNS TXT record.
+  If the Portal shows a verification key instead, create a temporary public
+  GitHub repository under [ORESoftware](https://github.com/ORESoftware) whose
+  name is exactly that key, then click **Verify** in the Portal.
 * Once verified, generate a **User Token** at
   <https://central.sonatype.com/account>. You'll get a *username* string and a
   *password* string. These are *not* your Portal login.
@@ -53,7 +56,7 @@ You need three things to publish to Maven Central:
   not into git):
 
   ```bash
-  gpg --armor --export-secret-keys <KEY_ID> > /tmp/maven-gpg-private-key.asc
+  scripts/export-release-gpg-key.sh <KEY_ID>
   ```
 
 ### 3. Repo secrets for the release workflow
@@ -70,6 +73,8 @@ In <https://github.com/async-java/async.java/settings/secrets/actions> add:
 Or set them from a checked-out repo with:
 
 ```bash
+gh auth login -h github.com -p ssh --skip-ssh-key -w -s repo,workflow
+
 export CENTRAL_USERNAME='...'
 export CENTRAL_PASSWORD='...'
 export MAVEN_GPG_PRIVATE_KEY="$(cat /tmp/maven-gpg-private-key.asc)"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,12 +8,14 @@ the snippet in [README](readme.md#installation).
 | Coordinate                                         | What it is                                | Notes                                       |
 | -------------------------------------------------- | ----------------------------------------- | ------------------------------------------- |
 | `io.github.async-java:async-java:<version>`        | This release line, on **Maven Central**.  | Current `<version>` lives in `pom.xml`.     |
+| `io.github.async-java:async-java:<version>`        | Same artifact on **GitHub Packages**.     | Published by the release workflow with `GITHUB_TOKEN`. |
 | `com.oresoftware:async.0.1:0.1.1012`               | The legacy artifact published in 2019.    | Frozen — kept on Central for compatibility. |
 | `com.github.async-java:async.java:<git-tag>`       | Same source, served by **JitPack**.       | Built on-demand from any git ref.           |
 
 JitPack is automatic — every git tag is buildable as soon as it's pushed
-(see [`jitpack.yml`](jitpack.yml)). The instructions below are only for the
-Maven Central path.
+(see [`jitpack.yml`](jitpack.yml)). GitHub Packages is automatic from the
+release workflow. The only manual credential setup is for the Maven Central /
+Sonatype path.
 
 ## One-time setup
 
@@ -69,16 +71,16 @@ In <https://github.com/async-java/async.java/settings/secrets/actions> add:
 
 ```bash
 # 1. Bump the version (drop the -SNAPSHOT suffix).
-#    Edit pom.xml: <version>0.2.0-SNAPSHOT</version> -> <version>0.2.0</version>
-git commit -am "Release 0.2.0"
+#    Edit pom.xml: <version>0.2.10-SNAPSHOT</version> -> <version>0.2.10</version>
+git commit -am "Release 0.2.10"
 
 # 2. Tag the commit. The release workflow only fires on `v*` tags.
-git tag v0.2.0
+git tag v0.2.10
 git push origin master --tags
 
 # 3. (Optional) Open development on the next version.
-#    Edit pom.xml: <version>0.2.0</version> -> <version>0.2.1-SNAPSHOT</version>
-git commit -am "Begin 0.2.1 development"
+#    Edit pom.xml: <version>0.2.10</version> -> <version>0.2.11-SNAPSHOT</version>
+git commit -am "Begin 0.2.11 development"
 git push
 ```
 
@@ -88,13 +90,17 @@ then:
 1. Verifies the tag matches `pom.xml`'s `<version>`.
 2. Runs `mvn test`.
 3. Imports the GPG key into the runner's agent.
-4. Runs `mvn -P release deploy`, which:
+4. Runs `mvn -P publish-artifacts,release deploy`, which:
    * Builds the jar.
    * Builds `-sources.jar` and `-javadoc.jar` (Maven Central requires both).
    * GPG-signs every artifact (jar / sources / javadoc / pom).
    * Uploads to the Central Portal's staging API.
    * Auto-publishes the staged release (because `<autoPublish>true</autoPublish>`).
-5. Creates a GitHub Release with the jars attached.
+5. Reconfigures Maven credentials for GitHub Packages (GitHub's
+   `setup-java` action rewrites `~/.m2/settings.xml` each time it runs).
+6. Runs `mvn -P publish-artifacts,github-packages deploy`, which publishes the same version to
+   `https://maven.pkg.github.com/async-java/async.java` using `GITHUB_TOKEN`.
+7. Creates a GitHub Release with the jars attached.
 
 The new version shows up on Maven Central within ~30 minutes of the workflow
 finishing.
@@ -135,10 +141,34 @@ Then:
 
 ```bash
 # Verify everything builds and signs locally first.
-mvn -P release -DskipTests verify
+mvn -P publish-artifacts,release -DskipTests verify
 
 # Deploy.
-mvn -P release deploy
+mvn -P publish-artifacts,release deploy
+```
+
+## Publishing to GitHub Packages locally
+
+CI uses the built-in `GITHUB_TOKEN`. For a local deploy, create a classic
+GitHub personal access token with `write:packages`, then add a `github` server
+to `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_CLASSIC_PAT_WITH_WRITE_PACKAGES</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Then:
+
+```bash
+mvn -P publish-artifacts,github-packages -DskipTests -Dgpg.skip=true deploy
 ```
 
 ## Snapshot releases

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,8 @@ the snippet in [README](readme.md#installation).
 
 | Coordinate                                         | What it is                                | Notes                                       |
 | -------------------------------------------------- | ----------------------------------------- | ------------------------------------------- |
-| `io.github.async-java:async-java:<version>`        | This release line, on **Maven Central**.  | Current `<version>` lives in `pom.xml`.     |
-| `io.github.async-java:async-java:<version>`        | Same artifact on **GitHub Packages**.     | Published by the release workflow with `GITHUB_TOKEN`. |
+| `io.github.oresoftware:async-java:<version>`        | This release line, on **Maven Central**.  | Current `<version>` lives in `pom.xml`.     |
+| `io.github.oresoftware:async-java:<version>`        | Same artifact on **GitHub Packages**.     | Published by the release workflow with `GITHUB_TOKEN`. |
 | `com.oresoftware:async.0.1:0.1.1012`               | The legacy artifact published in 2019.    | Frozen — kept on Central for compatibility. |
 | `com.github.async-java:async.java:<git-tag>`       | Same source, served by **JitPack**.       | Built on-demand from any git ref.           |
 
@@ -21,13 +21,13 @@ Sonatype path.
 
 You need three things to publish to Maven Central:
 
-### 1. A Sonatype Central Portal account + the `io.github.async-java` namespace
+### 1. A Sonatype Central Portal account + the `io.github.oresoftware` namespace
 
 * Sign up at <https://central.sonatype.com>.
-* Verify the `io.github.async-java` namespace. The Portal will tell you to
+* Verify the `io.github.oresoftware` namespace. The Portal will tell you to
   either:
-  * create a temporary public repo named `OSSRH-XXXXX` under the
-    [async-java](https://github.com/async-java) GitHub org (easiest), or
+  * confirm the automatically provisioned GitHub namespace for
+    [ORESoftware](https://github.com/ORESoftware), or
   * add a DNS TXT record.
 * Once verified, generate a **User Token** at
   <https://central.sonatype.com/account>. You'll get a *username* string and a

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -13,7 +13,7 @@
 #   <dependency>
 #     <groupId>com.github.async-java</groupId>
 #     <artifactId>async.java</artifactId>
-#     <version>v0.2.0</version>   <!-- any git tag, branch, or commit SHA -->
+#     <version>v0.2.10</version>  <!-- any git tag, branch, or commit SHA -->
 #   </dependency>
 #
 # JitPack defaults to OpenJDK 8 which won't compile this project. We need 17+ so
@@ -26,4 +26,4 @@ jdk:
 # 3.6.x, etc. all require Maven 3.6.3+). Download a modern Maven into the build
 # workspace so the plugin set in pom.xml stays current.
 install:
-  - curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz -o /tmp/mvn.tar.gz && tar -xzf /tmp/mvn.tar.gz -C /tmp && /tmp/apache-maven-3.9.9/bin/mvn -B -Dgpg.skip=true -DskipTests -Dmaven.javadoc.skip=true install
+  - curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz -o /tmp/mvn.tar.gz && tar -xzf /tmp/mvn.tar.gz -C /tmp && /tmp/apache-maven-3.9.16/bin/mvn -B -Dgpg.skip=true -DskipTests -Dmaven.javadoc.skip=true install

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,14 @@
         old: com.oresoftware:async1            (was never released to Central)
         old: com.oresoftware:async.0.1         (frozen at 0.1.1012, baked the version into
                                                 the artifactId — awkward to upgrade against)
-        new: io.github.async-java:async-java   (current release line, this PR onwards)
+        new: io.github.oresoftware:async-java   (current release line, this PR onwards)
 
-      The `io.github.<org>` group is auto-verifiable on the Sonatype Central Portal because
-      the async-java GitHub organisation already exists at https://github.com/async-java.
+      The `io.github.oresoftware` namespace matches the maintainer GitHub account used for
+      Central Portal verification. The source repository remains under
+      https://github.com/async-java/async.java.
       The old 0.1.1012 artifact stays in place on Maven Central for any existing consumer.
     -->
-    <groupId>io.github.async-java</groupId>
+    <groupId>io.github.oresoftware</groupId>
     <artifactId>async-java</artifactId>
     <packaging>jar</packaging>
     <version>0.2.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <groupId>io.github.async-java</groupId>
     <artifactId>async-java</artifactId>
     <packaging>jar</packaging>
-    <version>0.2.9</version>
+    <version>0.2.10</version>
     <name>async-java</name>
     <url>https://github.com/async-java/async.java</url>
 
@@ -26,8 +26,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!--
-          Bumped to 11 (LTS) so the project compiles on a supported JDK.
-          JDK 10 went EOL in September 2018; CI providers no longer ship it.
+          Bumped to 17 (LTS) so the project compiles on a supported baseline
+          while still testing runtime behavior on JDK 21 virtual threads.
         -->
         <jdk.version>17</jdk.version>
 
@@ -37,6 +37,15 @@
           The vertx-* dependencies are test-scope only.
         -->
         <vertx.version>3.9.16</vertx.version>
+        <jacoco.version>0.8.14</jacoco.version>
+        <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
+        <maven.dependency.plugin.version>3.9.0</maven.dependency.plugin.version>
+        <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
+        <maven.jar.plugin.version>3.4.2</maven.jar.plugin.version>
+        <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
+        <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
+        <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
+        <central.publishing.maven.plugin.version>0.10.0</central.publishing.maven.plugin.version>
 
         <!--
           log4j 1.2 reached EOL in 2015 with multiple unpatched CVEs.
@@ -130,7 +139,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <version>3.6.2</version>
+            <version>${vertx.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -182,7 +191,7 @@
         <!--
           Removed the legacy <finalName>async</finalName> override so the produced jar uses
           the standard ${project.artifactId}-${project.version} naming. Downstream consumers
-          expect to see `async-java-0.2.0.jar` in their dependency:tree, not `async.jar`.
+          expect to see `async-java-${project.version}.jar` in their dependency:tree, not `async.jar`.
         -->
         <plugins>
 
@@ -190,7 +199,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.3</version>
+                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -216,18 +225,22 @@
 
             <!--
               maven-compiler-plugin 2.3.2 was from 2010 and silently ignored the modern
-              `release` flag on JDK 11+. Pin to 3.8.1 — the lowest version that honors
-              `<release>` (added in 3.8.0) and that JitPack's bundled Maven 3.5.x can
-              still load. Newer versions of the plugin (3.10+, 3.13+) require Maven
-              3.6.3 which JitPack does not yet ship.
+              `release` flag on JDK 11+. Keep this on the stable 3.x line so the project
+              remains Maven 3-compatible while still compiling with modern JDKs.
             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${maven.compiler.plugin.version}</version>
                 <configuration>
                     <release>${jdk.version}</release>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
             </plugin>
 
             <!--
@@ -240,7 +253,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>${maven.jar.plugin.version}</version>
                 <configuration>
                     <excludes>
                         <exclude>**/log4j.properties</exclude>
@@ -252,7 +265,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>${maven.dependency.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -274,21 +287,19 @@
 
     <profiles>
         <!--
-          Activate with `mvn -P release deploy` (or via the .github/workflows/release.yml
-          tag-triggered workflow). Dev / CI builds do not activate this profile, so
-          contributors don't need GPG keys, sonatype credentials, or strict javadocs
-          just to run `mvn test`.
+          Attach the -sources.jar and -javadoc.jar artifacts expected by package registries.
+          Keep this separate from `release` so GitHub Packages can publish the same artifact
+          set without also activating Sonatype Central upload/signing behavior.
         -->
         <profile>
-            <id>release</id>
+            <id>publish-artifacts</id>
             <build>
                 <plugins>
-
                     <!-- Attach the -sources.jar Maven Central requires. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.1</version>
+                        <version>${maven.source.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -309,7 +320,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.6.3</version>
+                        <version>${maven.javadoc.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -331,7 +342,20 @@
                             </tags>
                         </configuration>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
 
+        <!--
+          Activate with `mvn -P publish-artifacts,release deploy` (or via the
+          .github/workflows/release.yml tag-triggered workflow). Dev / CI builds do not
+          activate this profile, so contributors don't need GPG keys or Sonatype credentials
+          just to run `mvn test`.
+        -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
                     <!--
                       GPG-sign the jar, sources, javadocs, and pom. The signing key is
                       imported into the agent in CI (see .github/workflows/release.yml);
@@ -341,7 +365,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.4</version>
+                        <version>${maven.gpg.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -375,7 +399,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.5.0</version>
+                        <version>${central.publishing.maven.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
@@ -386,6 +410,22 @@
 
                 </plugins>
             </build>
+        </profile>
+
+        <!--
+          Activate with `mvn -P publish-artifacts,github-packages deploy` after configuring a `github`
+          server in settings.xml. GitHub Actions can create that settings.xml via
+          actions/setup-java using GITHUB_ACTOR / GITHUB_TOKEN.
+        -->
+        <profile>
+            <id>github-packages</id>
+            <distributionManagement>
+                <repository>
+                    <id>github</id>
+                    <name>GitHub Packages</name>
+                    <url>https://maven.pkg.github.com/async-java/async.java</url>
+                </repository>
+            </distributionManagement>
         </profile>
     </profiles>
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 
 [![ci](https://github.com/async-java/async.java/actions/workflows/ci.yml/badge.svg)](https://github.com/async-java/async.java/actions/workflows/ci.yml)
 [![maven central](https://img.shields.io/maven-central/v/io.github.async-java/async-java)](https://central.sonatype.com/artifact/io.github.async-java/async-java)
-[![jdk](https://img.shields.io/badge/JDK-11%2B-blue)](#requirements)
+[![jdk](https://img.shields.io/badge/JDK-17%2B-blue)](#requirements)
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 ---
@@ -19,6 +19,7 @@
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Quickstart](#quickstart)
+- [Future and blocking-task interop](#future-and-blocking-task-interop)
 - [Control flow](#control-flow)
   - [Series](#series) · [Parallel](#parallel) · [Waterfall](#waterfall) ·
     [Race](#race) · [Inject](#inject)
@@ -63,6 +64,9 @@ The Java port of `async` is useful when:
 - [Vert.x](https://vertx.io/) — see [Using with Vert.x](#using-with-vertx).
 - [Akka](https://akka.io/) — the same callback discipline plugs into actor
   `tell` / `ask` flows.
+- Plain `Future` / `CompletableFuture` APIs — bridge callback combinators
+  with `WrapFuture`, `AsyncFut`, and the virtual-thread helpers in
+  `AsyncLoom`.
 - Plain `ExecutorService` — install your own executor with
   `NeoQueue.setExecutor(...)` and async.java's continuations run on it.
 
@@ -75,7 +79,7 @@ library solves orchestration."
 
 ## Requirements
 
-- **JDK 11+** (tested on 11, 17, 21).
+- **JDK 17+** (tested on 17 and 21).
 - SLF4J on the classpath (binding optional — pick `logback-classic`,
   `slf4j-simple`, etc.).
 
@@ -87,14 +91,14 @@ library solves orchestration."
 <dependency>
   <groupId>io.github.async-java</groupId>
   <artifactId>async-java</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.10</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```kotlin
-implementation("io.github.async-java:async-java:0.2.0")
+implementation("io.github.async-java:async-java:0.2.10")
 ```
 
 ### Snapshots
@@ -125,7 +129,7 @@ Need to try a branch, tag, or commit SHA before it lands on Central?
 <dependency>
   <groupId>com.github.async-java</groupId>
   <artifactId>async.java</artifactId>
-  <version>v0.2.0</version>  <!-- or a branch name, or a 10-char commit SHA -->
+  <version>v0.2.10</version>  <!-- or a branch name, or a 10-char commit SHA -->
 </dependency>
 ```
 
@@ -156,6 +160,109 @@ public class Quickstart {
 Every task receives an `IAsyncCallback<T, E>` and signals completion exactly
 once by calling `cb.done(error, value)`. The final callback runs after the
 last task settles — or immediately when any task surfaces an error.
+
+---
+
+## Future and blocking-task interop
+
+### Plain `Future`: async.java calls `get()` for you
+
+Legacy APIs often return plain JDK `Future<T>`, where the only way to retrieve
+the value is the blocking `future.get()`. Use `WrapFuture` or `AsyncFut` to
+move that blocking wait inside the library:
+
+```java
+ExecutorService legacyPool = Executors.newFixedThreadPool(8);
+ExecutorService waiters = AsyncLoom.isSupported()
+    ? AsyncLoom.newVirtualThreadPerTaskExecutor()
+    : Executors.newCachedThreadPool();
+
+try {
+  List<Future<Row>> futures = List.of(
+      legacyPool.submit(() -> fetchRow("a")),
+      legacyPool.submit(() -> fetchRow("b"))
+  );
+
+  CompletableFuture<List<Row>> rows = AsyncFut.ParallelFutures(waiters, futures);
+  rows.thenAccept(this::reply);
+} finally {
+  waiters.shutdown();
+  legacyPool.shutdown();
+}
+```
+
+For callback-style code, use `WrapFuture.fromFuture(...)`:
+
+```java
+Asyncc.Parallel(List.of(
+    WrapFuture.fromFuture(waiters, legacyPool.submit(() -> fetchA())),
+    WrapFuture.fromFuture(waiters, legacyPool.submit(() -> fetchB()))
+), (err, results) -> {
+    if (err != null) { reply.fail(err); return; }
+    reply.ok(results);
+});
+```
+
+### Blocking work on virtual threads
+
+On JDK 21+, `AsyncLoom` runs blocking `Callable` work on virtual threads and
+returns `CompletableFuture` results:
+
+```java
+CompletableFuture<List<Row>> rows = AsyncLoom.ParallelBlocking(List.of(
+    () -> jdbc.fetch("a"),
+    () -> jdbc.fetch("b")
+));
+
+CompletableFuture<List<Row>> ordered = AsyncLoom.SeriesBlocking(List.of(
+    () -> migrateStep1(),
+    () -> migrateStep2()
+));
+
+CompletableFuture<Integer> total = AsyncLoom.ReduceBlocking(
+    List.of("a", "b", "c"),
+    0,
+    (acc, id) -> acc + scoreBlocking(id));
+
+CompletableFuture<List<Path>> paths = AsyncLoom.ConcatBlocking(
+    tenants,
+    tenant -> listTenantFilesBlocking(tenant));
+```
+
+The same feature is available in callback form:
+
+```java
+Asyncc.SeriesBlocking(List.of(
+    () -> migrateStep1(),
+    () -> migrateStep2()
+), (err, results) -> {
+    if (err != null) { rollback(err); return; }
+    commit(results);
+});
+
+Asyncc.RaceBlocking(List.of(
+    () -> readPrimaryBlocking(key),
+    () -> readReplicaBlocking(key)
+), (err, value) -> {
+    if (err != null) { reply.fail(err); return; }
+    reply.ok(value);
+});
+```
+
+Existing `Parallel`, `Series`, `Reduce`, and `Concat` methods keep their
+current threading contract: tasks run on whichever thread invokes the callback.
+Use the `*Blocking` family when you want async.java to put blocking work on
+virtual threads for you.
+
+The repo also includes compile-checked examples under
+[`src/test/java/examples`](src/test/java/examples):
+
+- `FutureInteropExample` adapts plain JDK `Future` values without user-side
+  `get()` calls.
+- `LoomBlockingExample` shows `ParallelBlocking`, `SeriesBlocking`,
+  `RaceBlocking`, `ReduceBlocking`, and `ConcatBlocking`.
+- `CallbackBlockingExample` shows the callback-style `Asyncc.*Blocking`
+  wrappers.
 
 ---
 
@@ -502,7 +609,11 @@ NeoQueue.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
 // want a hard ceiling on concurrent CPU consumption.
 NeoQueue.setExecutor(Executors.newFixedThreadPool(
     Runtime.getRuntime().availableProcessors(),
-    Thread.ofPlatform().daemon(true).name("neoqueue-cpu-", 0).factory()));
+    r -> {
+      Thread t = new Thread(r, "neoqueue-cpu");
+      t.setDaemon(true);
+      return t;
+    }));
 ```
 
 For Vert.x apps, leave the default in place and let your combinator callbacks
@@ -588,7 +699,7 @@ lock.acquire((err, unlock) -> {
 ### Relationship to `StructuredTaskScope`
 
 `StructuredTaskScope` is the JDK's official structured-concurrency
-primitive — still in preview as of JDK 25 (JEP 505, the fifth preview).
+primitive — still in preview in JDK 26 (JEP 525, the sixth preview).
 A scope owns a set of subtasks, and when the scope's
 `try-with-resources` closes, all subtasks have settled.
 
@@ -793,7 +904,7 @@ consumers don't break:
 <dependency>
   <groupId>io.github.async-java</groupId>
   <artifactId>async-java</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.10</version>
 </dependency>
 ```
 
@@ -819,7 +930,7 @@ What's new since 0.1.1012:
   consistent memory model.
 - Replaced `throw new Error(...)` with `IllegalStateException` /
   `IllegalArgumentException` on application invariants.
-- Dropped JDK 10 baseline, JDK 11+ now required.
+- Dropped the old JDK 10/11-era baseline; JDK 17+ is now required.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full list.
 
@@ -830,10 +941,10 @@ See [CHANGELOG.md](CHANGELOG.md) for the full list.
 ```bash
 git clone https://github.com/async-java/async.java.git
 cd async.java
-mvn -B test         # 71 tests, ~10s on a warm cache
+mvn -B test         # 207 tests, ~15s on a warm cache
 ```
 
-Pull requests welcome. CI runs `mvn test` on JDK 11, 17, and 21 for every
+Pull requests welcome. CI runs `mvn test` on JDK 17 and 21 for every
 push and PR — see [.github/workflows/ci.yml](.github/workflows/ci.yml).
 
 Coding conventions:

--- a/readme.md
+++ b/readme.md
@@ -203,6 +203,22 @@ Asyncc.Parallel(List.of(
 });
 ```
 
+### CompletionStage: eager or lazy
+
+Use `WrapFuture.fromStage(stage)` when the `CompletionStage` is already in
+flight. Use `WrapFuture.fromStage(() -> stage)` when async.java should create
+the stage only when the combinator starts that task:
+
+```java
+Asyncc.Series(List.of(
+    WrapFuture.fromStage(() -> client.validateAsync(req)),
+    WrapFuture.fromStage(() -> client.persistAsync(req))
+), (err, results) -> {
+    if (err != null) { reply.fail(err); return; }
+    reply.ok(results);
+});
+```
+
 ### Blocking work on virtual threads
 
 On JDK 21+, `AsyncLoom` runs blocking `Callable` work on virtual threads and

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 > RxJava/Reactor.
 
 [![ci](https://github.com/async-java/async.java/actions/workflows/ci.yml/badge.svg)](https://github.com/async-java/async.java/actions/workflows/ci.yml)
-[![maven central](https://img.shields.io/maven-central/v/io.github.async-java/async-java)](https://central.sonatype.com/artifact/io.github.async-java/async-java)
+[![maven central](https://img.shields.io/maven-central/v/io.github.oresoftware/async-java)](https://central.sonatype.com/artifact/io.github.oresoftware/async-java)
 [![jdk](https://img.shields.io/badge/JDK-17%2B-blue)](#requirements)
 [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
@@ -89,7 +89,7 @@ library solves orchestration."
 
 ```xml
 <dependency>
-  <groupId>io.github.async-java</groupId>
+  <groupId>io.github.oresoftware</groupId>
   <artifactId>async-java</artifactId>
   <version>0.2.10</version>
 </dependency>
@@ -98,7 +98,7 @@ library solves orchestration."
 ### Gradle
 
 ```kotlin
-implementation("io.github.async-java:async-java:0.2.10")
+implementation("io.github.oresoftware:async-java:0.2.10")
 ```
 
 ### Snapshots
@@ -902,7 +902,7 @@ consumers don't break:
 
 <!-- new -->
 <dependency>
-  <groupId>io.github.async-java</groupId>
+  <groupId>io.github.oresoftware</groupId>
   <artifactId>async-java</artifactId>
   <version>0.2.10</version>
 </dependency>

--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,15 @@ CompletableFuture<List<Path>> paths = AsyncLoom.ConcatBlocking(
     tenant -> listTenantFilesBlocking(tenant));
 ```
 
+Promise-returning code has the same flattening shape without blocking:
+
+```java
+CompletableFuture<List<Order>> orders = AsyncFut.ConcatLimit(
+    8,
+    userIds,
+    userId -> orderClient.ordersForUserAsync(userId));
+```
+
 The same feature is available in callback form:
 
 ```java

--- a/scripts/check-release-readiness.sh
+++ b/scripts/check-release-readiness.sh
@@ -37,6 +37,7 @@ required=(
 )
 
 fail=0
+ci_gpg_secret_ready=0
 
 say() {
   printf '%s\n' "$*"
@@ -71,6 +72,10 @@ if secret_output="$(gh secret list --repo "$repo" 2>&1)"; then
       fail=1
     fi
   done
+  if printf '%s\n' "$secret_names" | grep -qx MAVEN_GPG_PRIVATE_KEY \
+      && printf '%s\n' "$secret_names" | grep -qx MAVEN_GPG_PASSPHRASE; then
+    ci_gpg_secret_ready=1
+  fi
 else
   say "missing: GitHub repo secret API access ($repo)"
   printf '%s\n' "$secret_output" | sed 's/^/  gh: /'
@@ -80,7 +85,15 @@ else
   fail=1
 fi
 
-check "local GPG secret key" sh -c 'gpg --list-secret-keys >/dev/null 2>&1 && [ -n "$(gpg --list-secret-keys --with-colons 2>/dev/null | awk -F: '\''$1 == "sec" { print; exit }'\'')" ]'
+if sh -c 'command -v gpg >/dev/null 2>&1 && gpg --list-secret-keys >/dev/null 2>&1 && [ -n "$(gpg --list-secret-keys --with-colons 2>/dev/null | awk -F: '\''$1 == "sec" { print; exit }'\'')" ]'; then
+  say "ok: local GPG secret key"
+elif [ "$ci_gpg_secret_ready" -eq 1 ]; then
+  say "ok: CI GPG signing secrets"
+  say "pending: local GPG secret key (needed only for local deploys)"
+else
+  say "missing: local GPG secret key"
+  fail=1
+fi
 check "current branch is pushed ($branch)" git ls-remote --exit-code origin "refs/heads/$branch"
 
 if git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then

--- a/scripts/check-release-readiness.sh
+++ b/scripts/check-release-readiness.sh
@@ -8,11 +8,25 @@ if [ "${1:-}" = "--pre-tag" ]; then
   repo="${2:-async-java/async.java}"
 fi
 
+pom_value() {
+  local expression="$1"
+  local fallback_tag="$2"
+  if command -v mvn >/dev/null 2>&1; then
+    mvn -B -q -DforceStdout help:evaluate -Dexpression="$expression"
+  else
+    awk -F'[<>]' -v tag="$fallback_tag" '$2 == tag { print $3; exit }' pom.xml
+  fi
+}
+
 if command -v mvn >/dev/null 2>&1; then
   version="$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version)"
 else
   version="$(awk -F'[<>]' '/<version>/ { print $3; exit }' pom.xml)"
 fi
+group_id="$(pom_value project.groupId groupId)"
+artifact_id="$(pom_value project.artifactId artifactId)"
+group_path="$(printf '%s' "$group_id" | tr . /)"
+metadata_path="$group_path/$artifact_id/maven-metadata.xml"
 tag="v$version"
 branch="$(git branch --show-current)"
 required=(
@@ -65,7 +79,7 @@ else
   fail=1
 fi
 
-metadata_url="https://repo.maven.apache.org/maven2/io/github/async-java/async-java/maven-metadata.xml"
+metadata_url="https://repo.maven.apache.org/maven2/$metadata_path"
 if curl -fsSL "$metadata_url" >/tmp/async-java-release-metadata.xml 2>/dev/null; then
   if grep -q "<version>$version</version>" /tmp/async-java-release-metadata.xml; then
     say "present: Maven Central version $version"

--- a/scripts/check-release-readiness.sh
+++ b/scripts/check-release-readiness.sh
@@ -53,10 +53,16 @@ check() {
   fi
 }
 
-check "gh authentication" gh auth status
-
 if gh auth status >/dev/null 2>&1; then
-  secret_names="$(gh secret list --repo "$repo" 2>/dev/null | awk '{print $1}')"
+  say "ok: gh authentication"
+else
+  say "missing: gh authentication"
+  fail=1
+fi
+
+if secret_output="$(gh secret list --repo "$repo" 2>&1)"; then
+  say "ok: GitHub repo secret API access ($repo)"
+  secret_names="$(printf '%s\n' "$secret_output" | awk '{print $1}')"
   for name in "${required[@]}"; do
     if printf '%s\n' "$secret_names" | grep -qx "$name"; then
       say "ok: repo secret $name"
@@ -65,6 +71,13 @@ if gh auth status >/dev/null 2>&1; then
       fail=1
     fi
   done
+else
+  say "missing: GitHub repo secret API access ($repo)"
+  printf '%s\n' "$secret_output" | sed 's/^/  gh: /'
+  for name in "${required[@]}"; do
+    say "missing: repo secret $name (unable to verify)"
+  done
+  fail=1
 fi
 
 check "local GPG secret key" sh -c 'gpg --list-secret-keys >/dev/null 2>&1 && [ -n "$(gpg --list-secret-keys --with-colons 2>/dev/null | awk -F: '\''$1 == "sec" { print; exit }'\'')" ]'

--- a/scripts/check-release-readiness.sh
+++ b/scripts/check-release-readiness.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:-async-java/async.java}"
+mode="post-tag"
+if [ "${1:-}" = "--pre-tag" ]; then
+  mode="pre-tag"
+  repo="${2:-async-java/async.java}"
+fi
+
+if command -v mvn >/dev/null 2>&1; then
+  version="$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version)"
+else
+  version="$(awk -F'[<>]' '/<version>/ { print $3; exit }' pom.xml)"
+fi
+tag="v$version"
+branch="$(git branch --show-current)"
+required=(
+  CENTRAL_USERNAME
+  CENTRAL_PASSWORD
+  MAVEN_GPG_PRIVATE_KEY
+  MAVEN_GPG_PASSPHRASE
+)
+
+fail=0
+
+say() {
+  printf '%s\n' "$*"
+}
+
+check() {
+  local label="$1"
+  shift
+  if "$@"; then
+    say "ok: $label"
+  else
+    say "missing: $label"
+    fail=1
+  fi
+}
+
+check "gh authentication" gh auth status
+
+if gh auth status >/dev/null 2>&1; then
+  secret_names="$(gh secret list --repo "$repo" 2>/dev/null | awk '{print $1}')"
+  for name in "${required[@]}"; do
+    if printf '%s\n' "$secret_names" | grep -qx "$name"; then
+      say "ok: repo secret $name"
+    else
+      say "missing: repo secret $name"
+      fail=1
+    fi
+  done
+fi
+
+check "local GPG secret key" sh -c 'gpg --list-secret-keys >/dev/null 2>&1 && [ -n "$(gpg --list-secret-keys --with-colons 2>/dev/null | awk -F: '\''$1 == "sec" { print; exit }'\'')" ]'
+check "current branch is pushed ($branch)" git ls-remote --exit-code origin "refs/heads/$branch"
+
+if git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
+  say "present: remote tag $tag"
+elif [ "$mode" = "pre-tag" ]; then
+  say "pending: remote tag $tag"
+else
+  say "missing: remote tag $tag"
+  fail=1
+fi
+
+metadata_url="https://repo.maven.apache.org/maven2/io/github/async-java/async-java/maven-metadata.xml"
+if curl -fsSL "$metadata_url" >/tmp/async-java-release-metadata.xml 2>/dev/null; then
+  if grep -q "<version>$version</version>" /tmp/async-java-release-metadata.xml; then
+    say "present: Maven Central version $version"
+  else
+    say "missing: Maven Central version $version"
+    fail=1
+  fi
+elif [ "$mode" = "pre-tag" ]; then
+  say "pending: Maven Central metadata at $metadata_url"
+else
+  say "missing: Maven Central metadata at $metadata_url"
+  fail=1
+fi
+
+exit "$fail"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# https://medium.freecodecamp.org/how-to-upload-an-open-source-java-library-to-maven-central-cac7ce2f57c
+# Local Maven Central release helper.
+#
+# Required env vars:
+#   CENTRAL_USERNAME
+#   CENTRAL_PASSWORD
+#   MAVEN_GPG_PASSPHRASE
+#
+# Required local state:
+#   a GPG secret key available to `gpg`
+#
+# GitHub Actions normally handles releases from tags. Use this only when CI is
+# unavailable and the Central Portal credentials are already configured.
 
-# https://dzone.com/articles/publish-your-artifacts-to-maven-central
+if [ -z "${GPG_TTY:-}" ] && tty >/dev/null 2>&1; then
+  export GPG_TTY
+  GPG_TTY="$(tty)"
+fi
 
-gpg --export -a 437A774CD1F35D00 | pbcopy  # public_key
-
-gpg --export -a 437a774cd1f35d00 | pbcopy
-
-export GPG_TTY=$(tty)
-mvn deploy  -Dmaven.test.skip=true #  -Dmaven.javadoc.skip=true +++ use "mvn clean deploy"
+mvn -s settings.xml -P publish-artifacts,release deploy "$@"

--- a/scripts/export-release-gpg-key.sh
+++ b/scripts/export-release-gpg-key.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "usage: $0 <GPG_KEY_ID> [/tmp/maven-gpg-private-key.asc]" >&2
+  exit 64
+fi
+
+key_id="$1"
+output="${2:-/tmp/maven-gpg-private-key.asc}"
+
+if ! gpg --list-secret-keys "$key_id" >/dev/null 2>&1; then
+  echo "missing local GPG secret key: $key_id" >&2
+  exit 66
+fi
+
+umask 077
+gpg --armor --export-secret-keys "$key_id" >"$output"
+
+echo "exported private key to $output"
+echo "next: export MAVEN_GPG_PRIVATE_KEY=\"\$(cat $output)\""

--- a/scripts/gpg.sh
+++ b/scripts/gpg.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <GPG_KEY_ID>" >&2
+  exit 64
+fi
 
-#gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys f1418e089845027e
-#gpg --keyserver hkp://keyserver.ubuntu.com --send-keys f1418e089845027e
+key_id="$1"
 
-
-gpg --keyserver http://pool.sks-keyservers.net --recv-keys f1418e089845027e
-gpg --keyserver http://keyserver.ubuntu.com --send-keys f1418e089845027e
-gpg --keyserver http://pool.sks-keyservers.net --recv-keys f1418e089845027e
-gpg --keyserver http://keyserver.ubuntu.com --send-keys f1418e089845027e
+gpg --keyserver hkps://keys.openpgp.org --send-keys "$key_id"
+gpg --keyserver hkps://keyserver.ubuntu.com --send-keys "$key_id"

--- a/scripts/set-release-secrets.sh
+++ b/scripts/set-release-secrets.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:-async-java/async.java}"
+
+required=(
+  CENTRAL_USERNAME
+  CENTRAL_PASSWORD
+  MAVEN_GPG_PRIVATE_KEY
+  MAVEN_GPG_PASSPHRASE
+)
+
+missing=0
+for name in "${required[@]}"; do
+  if [ -z "${!name:-}" ]; then
+    echo "missing env var: $name" >&2
+    missing=1
+  fi
+done
+
+if [ "$missing" -ne 0 ]; then
+  cat >&2 <<'EOF'
+
+Expected environment:
+
+  CENTRAL_USERNAME=... \
+  CENTRAL_PASSWORD=... \
+  MAVEN_GPG_PRIVATE_KEY="$(cat /tmp/maven-gpg-private-key.asc)" \
+  MAVEN_GPG_PASSPHRASE=... \
+  scripts/set-release-secrets.sh
+
+EOF
+  exit 64
+fi
+
+gh auth status >/dev/null
+
+for name in "${required[@]}"; do
+  printf '%s' "${!name}" | gh secret set "$name" --repo "$repo" --body-file -
+done
+
+echo "release secrets configured for $repo"

--- a/scripts/set-release-secrets.sh
+++ b/scripts/set-release-secrets.sh
@@ -36,7 +36,7 @@ fi
 gh auth status >/dev/null
 
 for name in "${required[@]}"; do
-  printf '%s' "${!name}" | gh secret set "$name" --repo "$repo" --body-file -
+  printf '%s' "${!name}" | gh secret set "$name" --repo "$repo"
 done
 
 echo "release secrets configured for $repo"

--- a/settings.xml
+++ b/settings.xml
@@ -1,27 +1,42 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
 
+  <!--
+    Safe local template for release maintainers.
 
-        <servers>
-            <server>
-                <id>ossrh</id>
-                <username>oresoftware</username>
-                <password>F1nintelD*t@</password>
-            </server>
-        </servers>
-        <profiles>
-            <profile>
-                <id>ossrh</id>
-                <activation>
-                    <activeByDefault>true</activeByDefault>
-                </activation>
-                <properties>
-                    <gpg.executable>gpg</gpg.executable>
-                    <gpg.passphrase>pass-phrase</gpg.passphrase>
-                </properties>
-            </profile>
-        </profiles>
+    Usage:
+      CENTRAL_USERNAME=... CENTRAL_PASSWORD=... \
+      MAVEN_GPG_PASSPHRASE=... \
+      mvn -s settings.xml -P publish-artifacts,release deploy
+
+    For GitHub Packages:
+      GITHUB_ACTOR=... GITHUB_TOKEN=... \
+      mvn -s settings.xml -P publish-artifacts,github-packages -Dgpg.skip=true deploy
+  -->
+
+  <servers>
+    <server>
+      <id>central</id>
+      <username>${env.CENTRAL_USERNAME}</username>
+      <password>${env.CENTRAL_PASSWORD}</password>
+    </server>
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>local-gpg</id>
+      <properties>
+        <gpg.executable>gpg</gpg.executable>
+        <gpg.passphrase>${env.MAVEN_GPG_PASSPHRASE}</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
 
 </settings>

--- a/src/main/java/org/ores/async/AsyncFut.java
+++ b/src/main/java/org/ores/async/AsyncFut.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -94,6 +96,20 @@ import java.util.function.Supplier;
  *               ))
  *           ).run(c)
  *   ), wrap(finalValue -&gt; reply.send(finalValue)));
+ * </pre>
+ *
+ * <p>Plain JDK {@link Future Futures} are also supported. Because {@code Future#get()} blocks,
+ * pass an executor that is dedicated to the wait. A virtual-thread executor from
+ * {@link AsyncLoom#newVirtualThreadPerTaskExecutor()} is ideal for many blocking waits:
+ *
+ * <pre>
+ *   ExecutorService vt = AsyncLoom.newVirtualThreadPerTaskExecutor();
+ *   try {
+ *       CompletableFuture&lt;List&lt;Payload&gt;&gt; all =
+ *           AsyncFut.ParallelFutures(vt, legacyClient.submitAll(requests));
+ *   } finally {
+ *       vt.shutdown();
+ *   }
  * </pre>
  *
  * @see Asyncc
@@ -210,6 +226,58 @@ public final class AsyncFut {
       wrapped.add(() -> stage);
     }
     return Race(wrapped);
+  }
+
+  // ---------------- Plain Future interop --------------------------------
+
+  /**
+   * Like {@link #ParallelF(List)}, but accepts plain JDK {@link Future Futures}.
+   *
+   * <p>The library calls {@link Future#get()} internally on {@code waitExecutor}, so callers do
+   * not have to write their own blocking bridge. This is intended for already-started legacy
+   * futures returned by APIs such as {@link java.util.concurrent.ExecutorService#submit}.
+   *
+   * <p>Important: {@code waitExecutor} is the executor used to wait on the futures, not
+   * necessarily the executor that produced them. Avoid using the same saturated fixed-size pool
+   * that still needs to run the underlying work. For many blocking waits, use
+   * {@link AsyncLoom#newVirtualThreadPerTaskExecutor()} on JDK 21+.
+   *
+   * @param <T> value type produced by each future
+   * @param waitExecutor executor used for blocking {@code Future#get()} waits
+   * @param futures already-started plain JDK futures
+   * @return a future of all results in input order
+   * @since 0.2.10
+   */
+  public static <T> CompletableFuture<List<T>> ParallelFutures(
+      final Executor waitExecutor,
+      final List<? extends Future<? extends T>> futures) {
+
+    final List<CompletionStage<T>> stages = new ArrayList<>(futures.size());
+    for (final Future<? extends T> future : futures) {
+      stages.add(WrapFuture.toCompletableFuture(waitExecutor, future));
+    }
+    return ParallelF(stages);
+  }
+
+  /**
+   * Like {@link #RaceF(List)}, but accepts plain JDK {@link Future Futures}. The library calls
+   * {@link Future#get()} internally on {@code waitExecutor}; the first completed wait wins.
+   *
+   * @param <T> value type produced by each future
+   * @param waitExecutor executor used for blocking {@code Future#get()} waits
+   * @param futures already-started plain JDK futures
+   * @return a future completed with the first future result
+   * @since 0.2.10
+   */
+  public static <T> CompletableFuture<T> RaceFutures(
+      final Executor waitExecutor,
+      final List<? extends Future<? extends T>> futures) {
+
+    final List<CompletionStage<T>> stages = new ArrayList<>(futures.size());
+    for (final Future<? extends T> future : futures) {
+      stages.add(WrapFuture.toCompletableFuture(waitExecutor, future));
+    }
+    return RaceF(stages);
   }
 
   // ---------------- Race -------------------------------------------------

--- a/src/main/java/org/ores/async/AsyncFut.java
+++ b/src/main/java/org/ores/async/AsyncFut.java
@@ -1,6 +1,7 @@
 package org.ores.async;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -61,6 +62,10 @@ import java.util.function.Supplier;
  *   // Map: async transform preserving input order
  *   CompletableFuture&lt;List&lt;Profile&gt;&gt; profiles =
  *       AsyncFut.Map(userIds, id -&gt; fetchProfileAsync(id));
+ *
+ *   // Concat: async map, then flatten one level
+ *   CompletableFuture&lt;List&lt;Order&gt;&gt; orders =
+ *       AsyncFut.Concat(userIds, id -&gt; fetchOrdersAsync(id));
  *
  *   // Reduce: sequential fold with an async reducer
  *   CompletableFuture&lt;BigDecimal&gt; total =
@@ -332,6 +337,76 @@ public final class AsyncFut {
         }
       }, c);
     });
+  }
+
+  // ---------------- Concat -----------------------------------------------
+
+  /**
+   * Async map + one-level flatten. {@code mapper(element)} runs for each element concurrently
+   * and returns a collection of zero or more output values; the returned future completes with
+   * all mapper results concatenated in input order.
+   *
+   * <pre>
+   *   CompletableFuture&lt;List&lt;Order&gt;&gt; orders =
+   *       AsyncFut.Concat(userIds, id -&gt; orderClient.ordersForUserAsync(id));
+   * </pre>
+   *
+   * @param <T> input value type
+   * @param <V> flattened output value type
+   * @param input values to map
+   * @param mapper async mapper producing zero or more output values
+   * @return flattened result future
+   * @since 0.2.10
+   */
+  public static <T, V> CompletableFuture<List<V>> Concat(
+      final Iterable<T> input,
+      final Function<? super T, ? extends CompletionStage<? extends Collection<? extends V>>> mapper) {
+
+    return ConcatLimit(Integer.MAX_VALUE, input, mapper);
+  }
+
+  /**
+   * Sequential version of {@link #Concat(Iterable, Function)}.
+   *
+   * @param <T> input value type
+   * @param <V> flattened output value type
+   * @param input values to map
+   * @param mapper async mapper producing zero or more output values
+   * @return flattened result future
+   * @since 0.2.10
+   */
+  public static <T, V> CompletableFuture<List<V>> ConcatSeries(
+      final Iterable<T> input,
+      final Function<? super T, ? extends CompletionStage<? extends Collection<? extends V>>> mapper) {
+
+    return ConcatLimit(1, input, mapper);
+  }
+
+  /**
+   * Bounded-concurrency version of {@link #Concat(Iterable, Function)}.
+   *
+   * @param <T> input value type
+   * @param <V> flattened output value type
+   * @param limit max in-flight mapper calls
+   * @param input values to map
+   * @param mapper async mapper producing zero or more output values
+   * @return flattened result future
+   * @since 0.2.10
+   */
+  public static <T, V> CompletableFuture<List<V>> ConcatLimit(
+      final int limit,
+      final Iterable<T> input,
+      final Function<? super T, ? extends CompletionStage<? extends Collection<? extends V>>> mapper) {
+
+    final List<T> items = toList(input);
+    final List<Supplier<? extends CompletionStage<Collection<? extends V>>>> suppliers =
+        new ArrayList<>(items.size());
+
+    for (final T item : items) {
+      suppliers.add(() -> widenCollectionStage(mapper.apply(item)));
+    }
+
+    return AsyncFut.ParallelLimit(limit, suppliers).thenApply(AsyncFut::flattenOne);
   }
 
   // ---------------- Reduce -----------------------------------------------
@@ -666,6 +741,24 @@ public final class AsyncFut {
       });
     }
     return out;
+  }
+
+  private static <V> List<V> flattenOne(
+      final List<? extends Collection<? extends V>> chunks) {
+
+    final List<V> out = new ArrayList<>();
+    for (final Collection<? extends V> chunk : chunks) {
+      if (chunk != null) {
+        out.addAll(chunk);
+      }
+    }
+    return out;
+  }
+
+  private static <V> CompletionStage<Collection<? extends V>> widenCollectionStage(
+      final CompletionStage<? extends Collection<? extends V>> stage) {
+
+    return stage.thenApply((Collection<? extends V> chunk) -> chunk);
   }
 
   private static <T> List<T> toList(final Iterable<T> input) {

--- a/src/main/java/org/ores/async/AsyncLoom.java
+++ b/src/main/java/org/ores/async/AsyncLoom.java
@@ -1,0 +1,527 @@
+package org.ores.async;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+/**
+ * Project Loom helpers for async.java.
+ *
+ * <p>This class is compiled for Java 17 but uses reflection to call the Java 21 virtual-thread
+ * APIs when they are present. That keeps the library usable on Java 17 while letting Java 21+
+ * consumers run blocking work on virtual threads with no extra adapter code.
+ *
+ * <h3>Run blocking tasks on virtual threads</h3>
+ *
+ * <pre>
+ *   CompletableFuture&lt;List&lt;Payload&gt;&gt; payloads = AsyncLoom.ParallelBlocking(List.of(
+ *       () -&gt; jdbcCall(id1),
+ *       () -&gt; jdbcCall(id2),
+ *       () -&gt; blockingHttpCall(id3)
+ *   ));
+ * </pre>
+ *
+ * <h3>Bridge legacy Futures without calling get()</h3>
+ *
+ * <pre>
+ *   ExecutorService vt = AsyncLoom.newVirtualThreadPerTaskExecutor();
+ *   try {
+ *       CompletableFuture&lt;List&lt;Payload&gt;&gt; payloads =
+ *           AsyncFut.ParallelFutures(vt, legacyFutures);
+ *   } finally {
+ *       vt.shutdown();
+ *   }
+ * </pre>
+ *
+ * <p>{@code AsyncLoom} is intentionally small: it does not replace {@link Asyncc} or
+ * {@link AsyncFut}. It supplies a cheap blocking executor so those combinators can orchestrate
+ * work that still uses blocking APIs.
+ *
+ * @see AsyncFut
+ * @see WrapFuture
+ * @since 0.2.10
+ */
+public final class AsyncLoom {
+
+  private static final Method NEW_VIRTUAL_THREAD_PER_TASK_EXECUTOR =
+      findMethod(java.util.concurrent.Executors.class, "newVirtualThreadPerTaskExecutor");
+
+  private static final Method THREAD_IS_VIRTUAL =
+      findMethod(Thread.class, "isVirtual");
+
+  private AsyncLoom() {}
+
+  /**
+   * Return {@code true} when this JVM exposes the Java 21 virtual-thread executor API.
+   *
+   * <p>On Java 17 this returns {@code false}. Calling methods that require virtual threads on
+   * such a JVM throws {@link UnsupportedOperationException}.
+   */
+  public static boolean isSupported() {
+    return NEW_VIRTUAL_THREAD_PER_TASK_EXECUTOR != null;
+  }
+
+  /**
+   * Return whether {@link Thread#currentThread()} is virtual. On Java 17 this returns
+   * {@code false}.
+   */
+  public static boolean isVirtualThread() {
+    return isVirtualThread(Thread.currentThread());
+  }
+
+  /**
+   * Return whether {@code thread} is virtual. On Java 17 this returns {@code false}.
+   *
+   * @param thread thread to inspect
+   */
+  public static boolean isVirtualThread(final Thread thread) {
+    if (THREAD_IS_VIRTUAL == null) {
+      return false;
+    }
+    try {
+      return Boolean.TRUE.equals(THREAD_IS_VIRTUAL.invoke(thread));
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw asRuntime(e);
+    }
+  }
+
+  /**
+   * Create a Java 21+ {@code Executors.newVirtualThreadPerTaskExecutor()} reflectively.
+   *
+   * <p>The caller owns the returned executor and should call {@link ExecutorService#shutdown()}
+   * when done. On Java 17 this throws {@link UnsupportedOperationException}.
+   *
+   * @return a new virtual-thread-per-task executor
+   */
+  public static ExecutorService newVirtualThreadPerTaskExecutor() {
+    if (NEW_VIRTUAL_THREAD_PER_TASK_EXECUTOR == null) {
+      throw new UnsupportedOperationException(
+          "Virtual threads require JDK 21+; this runtime does not expose "
+              + "Executors.newVirtualThreadPerTaskExecutor().");
+    }
+    try {
+      return (ExecutorService) NEW_VIRTUAL_THREAD_PER_TASK_EXECUTOR.invoke(null);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw asRuntime(e);
+    }
+  }
+
+  /**
+   * Install a virtual-thread executor for {@link NeoQueue} continuations.
+   *
+   * <p>The returned executor is now owned by {@code NeoQueue}; keep a reference if your process
+   * needs to shut it down explicitly. A later call to {@link NeoQueue#setExecutor(ExecutorService)}
+   * replaces it.
+   *
+   * @return the executor installed into {@code NeoQueue}
+   */
+  public static ExecutorService installNeoQueueExecutor() {
+    final ExecutorService exec = newVirtualThreadPerTaskExecutor();
+    NeoQueue.setExecutor(exec);
+    return exec;
+  }
+
+  /**
+   * Run one blocking {@link Callable} on a virtual thread and return its result as a
+   * {@link CompletableFuture}.
+   *
+   * <p>The temporary virtual-thread executor is shut down when the callable completes.
+   *
+   * @param <V> callable result type
+   * @param callable blocking work to run on a virtual thread
+   * @return a future completed with the callable result
+   */
+  public static <V> CompletableFuture<V> supply(final Callable<V> callable) {
+    final ExecutorService exec = newVirtualThreadPerTaskExecutor();
+    return WrapFuture.toCompletableFuture(exec, callable)
+        .whenComplete((value, err) -> exec.shutdown());
+  }
+
+  /**
+   * Run one blocking {@link ThrowingRunnable} on a virtual thread.
+   *
+   * @param runnable blocking work to run on a virtual thread
+   * @return a future completed when the runnable finishes
+   */
+  public static CompletableFuture<Void> run(final ThrowingRunnable runnable) {
+    return supply(() -> {
+      runnable.run();
+      return null;
+    });
+  }
+
+  /**
+   * Wrap a blocking callable as an async.java task. Each task invocation uses one virtual
+   * thread and shuts down its temporary executor after completion.
+   *
+   * @param <V> callable result type
+   * @param callable blocking work to run
+   * @return async.java task
+   */
+  public static <V> Asyncc.AsyncTask<V, Throwable> task(final Callable<V> callable) {
+    return c -> supply(callable).whenComplete((value, err) -> {
+      if (err != null) {
+        c.fail(err);
+      } else {
+        c.success(value);
+      }
+    });
+  }
+
+  /**
+   * Run blocking callables concurrently on virtual threads and collect results in input order.
+   *
+   * @param <V> callable result type
+   * @param tasks blocking tasks to run
+   * @return a future of all task results
+   */
+  public static <V> CompletableFuture<List<V>> ParallelBlocking(
+      final List<? extends Callable<V>> tasks) {
+
+    final ExecutorService exec = newVirtualThreadPerTaskExecutor();
+    return AsyncFut.Parallel(toStageSuppliers(exec, tasks))
+        .whenComplete((value, err) -> exec.shutdown());
+  }
+
+  /**
+   * Run blocking callables on virtual threads with at most {@code limit} tasks in flight.
+   *
+   * @param <V> callable result type
+   * @param limit max in-flight tasks
+   * @param tasks blocking tasks to run
+   * @return a future of all task results in input order
+   */
+  public static <V> CompletableFuture<List<V>> ParallelBlocking(
+      final int limit,
+      final List<? extends Callable<V>> tasks) {
+
+    final ExecutorService exec = newVirtualThreadPerTaskExecutor();
+    return AsyncFut.ParallelLimit(limit, toStageSuppliers(exec, tasks))
+        .whenComplete((value, err) -> exec.shutdown());
+  }
+
+  /**
+   * Named alias for {@link #ParallelBlocking(int, List)}.
+   *
+   * @param <V> callable result type
+   * @param limit max in-flight tasks
+   * @param tasks blocking tasks to run
+   * @return a future of all task results in input order
+   */
+  public static <V> CompletableFuture<List<V>> ParallelLimitBlocking(
+      final int limit,
+      final List<? extends Callable<V>> tasks) {
+
+    return ParallelBlocking(limit, tasks);
+  }
+
+  /**
+   * Run blocking callables sequentially on virtual threads and collect each result.
+   *
+   * @param <V> callable result type
+   * @param tasks blocking tasks to run
+   * @return a future of all task results in input order
+   */
+  public static <V> CompletableFuture<List<V>> SeriesBlocking(
+      final List<? extends Callable<V>> tasks) {
+
+    final ExecutorService exec = newVirtualThreadPerTaskExecutor();
+    return AsyncFut.Series(toStageSuppliers(exec, tasks))
+        .whenComplete((value, err) -> exec.shutdown());
+  }
+
+  /**
+   * Run blocking callables concurrently on virtual threads and complete with the first result.
+   *
+   * @param <V> callable result type
+   * @param tasks blocking tasks to race
+   * @return a future completed with the first task result
+   */
+  public static <V> CompletableFuture<V> RaceBlocking(
+      final List<? extends Callable<V>> tasks) {
+
+    final ExecutorService exec = newVirtualThreadPerTaskExecutor();
+    return AsyncFut.Race(toStageSuppliers(exec, tasks))
+        .whenComplete((value, err) -> exec.shutdown());
+  }
+
+  /**
+   * Map each input value through a blocking function on virtual threads. Results preserve input
+   * order.
+   *
+   * @param <T> input value type
+   * @param <V> mapped value type
+   * @param input values to map
+   * @param mapper blocking mapper to run on virtual threads
+   * @return a future of mapped results
+   */
+  public static <T, V> CompletableFuture<List<V>> MapBlocking(
+      final Iterable<T> input,
+      final BlockingFunction<? super T, V> mapper) {
+
+    return MapLimitBlocking(Integer.MAX_VALUE, input, mapper);
+  }
+
+  /**
+   * Map each input value through a blocking function on virtual threads with at most
+   * {@code limit} mapper calls in flight.
+   *
+   * @param <T> input value type
+   * @param <V> mapped value type
+   * @param limit max in-flight mapper calls
+   * @param input values to map
+   * @param mapper blocking mapper to run on virtual threads
+   * @return a future of mapped results
+   */
+  public static <T, V> CompletableFuture<List<V>> MapLimitBlocking(
+      final int limit,
+      final Iterable<T> input,
+      final BlockingFunction<? super T, V> mapper) {
+
+    final ExecutorService exec = newVirtualThreadPerTaskExecutor();
+    final List<Supplier<? extends CompletionStage<V>>> suppliers = new ArrayList<>();
+    final Iterator<T> it = input.iterator();
+    while (it.hasNext()) {
+      final T item = it.next();
+      suppliers.add(() -> WrapFuture.toCompletableFuture(exec, () -> mapper.apply(item)));
+    }
+
+    return AsyncFut.ParallelLimit(limit, suppliers)
+        .whenComplete((value, err) -> exec.shutdown());
+  }
+
+  /**
+   * Run a blocking async-style each function on virtual threads. The result future completes
+   * with {@code null} when all items have been processed.
+   *
+   * @param <T> input value type
+   * @param input values to process
+   * @param consumer blocking per-item function
+   * @return completion future
+   */
+  public static <T> CompletableFuture<Void> EachBlocking(
+      final Iterable<T> input,
+      final BlockingConsumer<? super T> consumer) {
+
+    return EachLimitBlocking(Integer.MAX_VALUE, input, consumer);
+  }
+
+  /**
+   * Run a blocking async-style each function on virtual threads with at most {@code limit}
+   * calls in flight.
+   *
+   * @param <T> input value type
+   * @param limit max in-flight calls
+   * @param input values to process
+   * @param consumer blocking per-item function
+   * @return completion future
+   */
+  public static <T> CompletableFuture<Void> EachLimitBlocking(
+      final int limit,
+      final Iterable<T> input,
+      final BlockingConsumer<? super T> consumer) {
+
+    return MapLimitBlocking(limit, input, item -> {
+      consumer.accept(item);
+      return null;
+    }).thenApply(ignored -> null);
+  }
+
+  /**
+   * Sequentially reduce input values with a blocking reducer. Each reducer call runs on a
+   * virtual thread, and the next reducer call starts only after the prior one completes.
+   *
+   * @param <T> input value type
+   * @param <V> accumulator/result type
+   * @param input values to reduce
+   * @param identity initial accumulator value
+   * @param reducer blocking reducer
+   * @return final accumulator future
+   */
+  public static <T, V> CompletableFuture<V> ReduceBlocking(
+      final Iterable<T> input,
+      final V identity,
+      final BlockingReducer<V, ? super T> reducer) {
+
+    final ExecutorService exec = newVirtualThreadPerTaskExecutor();
+    return AsyncFut.Reduce(input, identity,
+        (acc, item) -> WrapFuture.toCompletableFuture(exec, () -> reducer.reduce(acc, item)))
+        .whenComplete((value, err) -> exec.shutdown());
+  }
+
+  /**
+   * Run a blocking function {@code n} times on virtual threads and collect the results in index
+   * order.
+   *
+   * @param <V> result type
+   * @param n number of calls
+   * @param task blocking index-aware function
+   * @return ordered result future
+   */
+  public static <V> CompletableFuture<List<V>> TimesBlocking(
+      final int n,
+      final BlockingIntFunction<V> task) {
+
+    final List<Callable<V>> tasks = new ArrayList<>(n);
+    for (int i = 0; i < n; i++) {
+      final int index = i;
+      tasks.add(() -> task.apply(index));
+    }
+    return ParallelBlocking(tasks);
+  }
+
+  /**
+   * Map each item to a collection on virtual threads, then concatenate one level while
+   * preserving input order.
+   *
+   * @param <T> input value type
+   * @param <V> flattened output value type
+   * @param input values to map
+   * @param mapper blocking mapper producing zero or more output values
+   * @return flattened result future
+   */
+  public static <T, V> CompletableFuture<List<V>> ConcatBlocking(
+      final Iterable<T> input,
+      final BlockingFunction<? super T, ? extends Collection<? extends V>> mapper) {
+
+    return ConcatLimitBlocking(Integer.MAX_VALUE, input, mapper);
+  }
+
+  /**
+   * Sequential version of {@link #ConcatBlocking(Iterable, BlockingFunction)}.
+   *
+   * @param <T> input value type
+   * @param <V> flattened output value type
+   * @param input values to map
+   * @param mapper blocking mapper producing zero or more output values
+   * @return flattened result future
+   */
+  public static <T, V> CompletableFuture<List<V>> ConcatSeriesBlocking(
+      final Iterable<T> input,
+      final BlockingFunction<? super T, ? extends Collection<? extends V>> mapper) {
+
+    return ConcatLimitBlocking(1, input, mapper);
+  }
+
+  /**
+   * Bounded-concurrency version of {@link #ConcatBlocking(Iterable, BlockingFunction)}.
+   *
+   * @param <T> input value type
+   * @param <V> flattened output value type
+   * @param limit max in-flight mapper calls
+   * @param input values to map
+   * @param mapper blocking mapper producing zero or more output values
+   * @return flattened result future
+   */
+  public static <T, V> CompletableFuture<List<V>> ConcatLimitBlocking(
+      final int limit,
+      final Iterable<T> input,
+      final BlockingFunction<? super T, ? extends Collection<? extends V>> mapper) {
+
+    final ExecutorService exec = newVirtualThreadPerTaskExecutor();
+    final List<Supplier<? extends CompletionStage<Collection<? extends V>>>> suppliers =
+        new ArrayList<>();
+    final Iterator<T> it = input.iterator();
+    while (it.hasNext()) {
+      final T item = it.next();
+      suppliers.add(() -> WrapFuture.toCompletableFuture(exec, () -> mapper.apply(item)));
+    }
+
+    return AsyncFut.ParallelLimit(limit, suppliers)
+        .thenApply(AsyncLoom::flattenOne)
+        .whenComplete((value, err) -> exec.shutdown());
+  }
+
+  /**
+   * Functional interface for {@link #run(ThrowingRunnable)}.
+   */
+  @FunctionalInterface
+  public interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  /**
+   * Blocking function used by virtual-thread collection helpers.
+   */
+  @FunctionalInterface
+  public interface BlockingFunction<T, V> {
+    V apply(T value) throws Exception;
+  }
+
+  /**
+   * Blocking reducer used by {@link #ReduceBlocking(Iterable, Object, BlockingReducer)}.
+   */
+  @FunctionalInterface
+  public interface BlockingReducer<V, T> {
+    V reduce(V accumulator, T value) throws Exception;
+  }
+
+  /**
+   * Blocking consumer used by {@link #EachBlocking(Iterable, BlockingConsumer)}.
+   */
+  @FunctionalInterface
+  public interface BlockingConsumer<T> {
+    void accept(T value) throws Exception;
+  }
+
+  /**
+   * Blocking index-aware function used by {@link #TimesBlocking(int, BlockingIntFunction)}.
+   */
+  @FunctionalInterface
+  public interface BlockingIntFunction<V> {
+    V apply(int index) throws Exception;
+  }
+
+  private static <V> List<Supplier<? extends CompletionStage<V>>> toStageSuppliers(
+      final ExecutorService exec,
+      final List<? extends Callable<V>> tasks) {
+
+    final List<Supplier<? extends CompletionStage<V>>> suppliers = new ArrayList<>(tasks.size());
+    for (final Callable<V> task : tasks) {
+      suppliers.add(() -> WrapFuture.toCompletableFuture(exec, task));
+    }
+    return suppliers;
+  }
+
+  private static <V> List<V> flattenOne(
+      final List<? extends Collection<? extends V>> chunks) {
+
+    final List<V> out = new ArrayList<>();
+    for (final Collection<? extends V> chunk : chunks) {
+      if (chunk != null) {
+        out.addAll(chunk);
+      }
+    }
+    return out;
+  }
+
+  private static Method findMethod(final Class<?> type, final String name) {
+    try {
+      return type.getMethod(name);
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  private static RuntimeException asRuntime(final ReflectiveOperationException e) {
+    if (e instanceof InvocationTargetException ite && ite.getCause() != null) {
+      final Throwable cause = ite.getCause();
+      if (cause instanceof RuntimeException re) {
+        return re;
+      }
+      if (cause instanceof Error error) {
+        throw error;
+      }
+      return new RuntimeException(cause);
+    }
+    return new RuntimeException(e);
+  }
+}

--- a/src/main/java/org/ores/async/Asyncc.java
+++ b/src/main/java/org/ores/async/Asyncc.java
@@ -1,6 +1,9 @@
 package org.ores.async;
 
 import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
  * Entry point for async.java's combinators.
@@ -344,6 +347,295 @@ public class Asyncc {
   public interface AsyncTask<T, E> {
     //    public void run(AsyncCallback<T, E> cb);
     void run(IAsyncCallback<T, E> cb);
+  }
+
+  /**
+   * Run blocking {@link Callable} tasks concurrently on Java 21+ virtual threads and report
+   * the ordered results through the normal error-first callback.
+   *
+   * <p>This is a callback-style wrapper around {@link AsyncLoom#ParallelBlocking(List)}. On
+   * Java 17, where virtual threads are unavailable, the callback receives an
+   * {@link UnsupportedOperationException}.
+   *
+   * @param <T> result type
+   * @param tasks blocking tasks to run
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T> void ParallelBlocking(
+      final List<? extends Callable<T>> tasks,
+      final IAsyncCallback<List<T>, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.ParallelBlocking(tasks), f);
+  }
+
+  /**
+   * Run blocking {@link Callable} tasks on Java 21+ virtual threads with at most {@code limit}
+   * tasks in flight.
+   *
+   * @param <T> result type
+   * @param limit max in-flight tasks
+   * @param tasks blocking tasks to run
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T> void ParallelLimitBlocking(
+      final int limit,
+      final List<? extends Callable<T>> tasks,
+      final IAsyncCallback<List<T>, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.ParallelBlocking(limit, tasks), f);
+  }
+
+  /**
+   * Run blocking {@link Callable} tasks sequentially on Java 21+ virtual threads.
+   *
+   * <p>Each step starts only after the previous step has completed, preserving the normal
+   * {@code Series} contract. The blocking work itself runs on a virtual thread so callers do
+   * not have to call {@code get()}, {@code join()}, or blocking I/O directly on their current
+   * thread.
+   *
+   * @param <T> result type
+   * @param tasks blocking tasks to run in order
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T> void SeriesBlocking(
+      final List<? extends Callable<T>> tasks,
+      final IAsyncCallback<List<T>, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.SeriesBlocking(tasks), f);
+  }
+
+  /**
+   * Race blocking {@link Callable} tasks on Java 21+ virtual threads and report the first
+   * result.
+   *
+   * @param <T> result type
+   * @param tasks blocking tasks to race
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T> void RaceBlocking(
+      final List<? extends Callable<T>> tasks,
+      final IAsyncCallback<T, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.RaceBlocking(tasks), f);
+  }
+
+  /**
+   * Map values with a blocking mapper on Java 21+ virtual threads.
+   *
+   * @param <T> input value type
+   * @param <V> mapped value type
+   * @param input values to map
+   * @param mapper blocking mapper
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T, V> void MapBlocking(
+      final Iterable<T> input,
+      final AsyncLoom.BlockingFunction<? super T, V> mapper,
+      final IAsyncCallback<List<V>, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.MapBlocking(input, mapper), f);
+  }
+
+  /**
+   * Map values with a blocking mapper on Java 21+ virtual threads with at most {@code limit}
+   * mapper calls in flight.
+   *
+   * @param <T> input value type
+   * @param <V> mapped value type
+   * @param limit max in-flight mapper calls
+   * @param input values to map
+   * @param mapper blocking mapper
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T, V> void MapLimitBlocking(
+      final int limit,
+      final Iterable<T> input,
+      final AsyncLoom.BlockingFunction<? super T, V> mapper,
+      final IAsyncCallback<List<V>, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.MapLimitBlocking(limit, input, mapper), f);
+  }
+
+  /**
+   * Process each value with a blocking consumer on Java 21+ virtual threads.
+   *
+   * @param <T> input value type
+   * @param input values to process
+   * @param consumer blocking consumer
+   * @param f final error-only callback
+   * @since 0.2.10
+   */
+  public static <T> void EachBlocking(
+      final Iterable<T> input,
+      final AsyncLoom.BlockingConsumer<? super T> consumer,
+      final NeoEachI.IEachCallback<Throwable> f) {
+
+    pipeLoomEach(() -> AsyncLoom.EachBlocking(input, consumer), f);
+  }
+
+  /**
+   * Process each value with a blocking consumer on Java 21+ virtual threads with at most
+   * {@code limit} calls in flight.
+   *
+   * @param <T> input value type
+   * @param limit max in-flight calls
+   * @param input values to process
+   * @param consumer blocking consumer
+   * @param f final error-only callback
+   * @since 0.2.10
+   */
+  public static <T> void EachLimitBlocking(
+      final int limit,
+      final Iterable<T> input,
+      final AsyncLoom.BlockingConsumer<? super T> consumer,
+      final NeoEachI.IEachCallback<Throwable> f) {
+
+    pipeLoomEach(() -> AsyncLoom.EachLimitBlocking(limit, input, consumer), f);
+  }
+
+  /**
+   * Reduce values sequentially with a blocking reducer on Java 21+ virtual threads.
+   *
+   * @param <T> input value type
+   * @param <V> accumulator/result type
+   * @param initialVal initial accumulator
+   * @param input values to reduce
+   * @param reducer blocking reducer
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T, V> void ReduceBlocking(
+      final V initialVal,
+      final Iterable<T> input,
+      final AsyncLoom.BlockingReducer<V, ? super T> reducer,
+      final IAsyncCallback<V, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.ReduceBlocking(input, initialVal, reducer), f);
+  }
+
+  /**
+   * Run a blocking index-aware function {@code count} times on Java 21+ virtual threads.
+   *
+   * @param <T> result type
+   * @param count number of calls
+   * @param task blocking index-aware task
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T> void TimesBlocking(
+      final int count,
+      final AsyncLoom.BlockingIntFunction<T> task,
+      final IAsyncCallback<List<T>, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.TimesBlocking(count, task), f);
+  }
+
+  /**
+   * Map each value to a collection on Java 21+ virtual threads, then concatenate one level.
+   *
+   * @param <T> input value type
+   * @param <V> flattened output value type
+   * @param input values to map
+   * @param mapper blocking mapper producing zero or more values
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T, V> void ConcatBlocking(
+      final Iterable<T> input,
+      final AsyncLoom.BlockingFunction<? super T, ? extends Collection<? extends V>> mapper,
+      final IAsyncCallback<List<V>, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.ConcatBlocking(input, mapper), f);
+  }
+
+  /**
+   * Sequential version of {@link #ConcatBlocking(Iterable, AsyncLoom.BlockingFunction, IAsyncCallback)}.
+   *
+   * @param <T> input value type
+   * @param <V> flattened output value type
+   * @param input values to map
+   * @param mapper blocking mapper producing zero or more values
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T, V> void ConcatSeriesBlocking(
+      final Iterable<T> input,
+      final AsyncLoom.BlockingFunction<? super T, ? extends Collection<? extends V>> mapper,
+      final IAsyncCallback<List<V>, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.ConcatSeriesBlocking(input, mapper), f);
+  }
+
+  /**
+   * Bounded-concurrency version of
+   * {@link #ConcatBlocking(Iterable, AsyncLoom.BlockingFunction, IAsyncCallback)}.
+   *
+   * @param <T> input value type
+   * @param <V> flattened output value type
+   * @param limit max in-flight mapper calls
+   * @param input values to map
+   * @param mapper blocking mapper producing zero or more values
+   * @param f final callback
+   * @since 0.2.10
+   */
+  public static <T, V> void ConcatLimitBlocking(
+      final int limit,
+      final Iterable<T> input,
+      final AsyncLoom.BlockingFunction<? super T, ? extends Collection<? extends V>> mapper,
+      final IAsyncCallback<List<V>, Throwable> f) {
+
+    pipeLoomFuture(() -> AsyncLoom.ConcatLimitBlocking(limit, input, mapper), f);
+  }
+
+  private interface FutSupplier<T> {
+    CompletableFuture<T> get();
+  }
+
+  private static <T> void pipeLoomFuture(
+      final FutSupplier<T> supplier,
+      final IAsyncCallback<T, Throwable> f) {
+
+    try {
+      supplier.get().whenComplete((value, err) -> {
+        if (err != null) {
+          f.fail(unwrapCompletion(err));
+        } else {
+          f.success(value);
+        }
+      });
+    } catch (Throwable t) {
+      f.fail(unwrapCompletion(t));
+    }
+  }
+
+  private static void pipeLoomEach(
+      final FutSupplier<Void> supplier,
+      final NeoEachI.IEachCallback<Throwable> f) {
+
+    try {
+      supplier.get().whenComplete((value, err) -> {
+        if (err != null) {
+          f.done(unwrapCompletion(err));
+        } else {
+          f.done(null);
+        }
+      });
+    } catch (Throwable t) {
+      f.done(unwrapCompletion(t));
+    }
+  }
+
+  private static Throwable unwrapCompletion(final Throwable err) {
+    if (err instanceof CompletionException && err.getCause() != null) {
+      return err.getCause();
+    }
+    return err;
   }
   
   // begin parallel

--- a/src/main/java/org/ores/async/WrapFuture.java
+++ b/src/main/java/org/ores/async/WrapFuture.java
@@ -1,9 +1,13 @@
 package org.ores.async;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -21,6 +25,8 @@ import java.util.function.Consumer;
  *       (a JDBC async driver, an HTTP client) inside an async.java combinator.</li>
  *   <li>{@link #fromCallable(Executor, Callable)} — wrap a sync, possibly-blocking
  *       {@link Callable} as an async.java task, dispatching it onto the provided executor.</li>
+ *   <li>{@link #fromFuture(Executor, Future)} — wrap a plain JDK {@link Future} as an async.java
+ *       task, waiting on the provided executor so the caller thread is never blocked.</li>
  * </ul>
  *
  * <h3>The {@code toFuture} idiom</h3>
@@ -180,6 +186,127 @@ public final class WrapFuture {
   }
 
   /**
+   * Adapt a plain JDK {@link Future} to a {@link CompletableFuture}.
+   *
+   * <p>{@code Future#get()} is blocking, so this method waits on the supplied {@code executor}
+   * instead of blocking the caller. For large numbers of blocking futures, a virtual-thread
+   * executor is a natural fit:
+   *
+   * <pre>
+   *   try (var vt = AsyncLoom.newVirtualThreadPerTaskExecutor()) {
+   *       CompletableFuture&lt;Response&gt; cf = WrapFuture.toCompletableFuture(vt, legacyFuture);
+   *   }
+   * </pre>
+   *
+   * <p>If the returned {@code CompletableFuture} is cancelled, cancellation is propagated to the
+   * underlying {@code Future}. If {@code future.get()} throws {@link ExecutionException}, the
+   * original cause is used for exceptional completion.
+   *
+   * @param <V> value type produced by the future
+   * @param exec executor used for the blocking {@code Future#get()} wait
+   * @param future legacy/plain JDK future to adapt
+   * @return a {@code CompletableFuture} mirroring the supplied future
+   * @since 0.2.10
+   */
+  public static <V> CompletableFuture<V> toCompletableFuture(
+      final Executor exec,
+      final Future<? extends V> future) {
+
+    Objects.requireNonNull(exec, "exec");
+    Objects.requireNonNull(future, "future");
+
+    final CompletableFuture<V> cf = new CompletableFuture<>() {
+      @Override
+      public boolean cancel(final boolean mayInterruptIfRunning) {
+        future.cancel(mayInterruptIfRunning);
+        return super.cancel(mayInterruptIfRunning);
+      }
+    };
+
+    try {
+      exec.execute(() -> {
+        try {
+          cf.complete(future.get());
+        } catch (CancellationException e) {
+          cf.cancel(false);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          cf.completeExceptionally(e);
+        } catch (ExecutionException e) {
+          cf.completeExceptionally(e.getCause() == null ? e : e.getCause());
+        } catch (Throwable t) {
+          cf.completeExceptionally(t);
+        }
+      });
+    } catch (Throwable t) {
+      cf.completeExceptionally(t);
+    }
+
+    return cf;
+  }
+
+  /**
+   * Dispatch a checked {@link Callable} onto an executor and expose its result as a
+   * {@link CompletableFuture}. Unlike {@link CompletableFuture#supplyAsync}, checked exceptions
+   * from {@code callable.call()} are preserved directly as the exceptional completion cause.
+   *
+   * @param <V> value type produced by the callable
+   * @param exec executor to run the callable on
+   * @param callable synchronous work to perform
+   * @return a {@code CompletableFuture} for the callable result
+   * @since 0.2.10
+   */
+  public static <V> CompletableFuture<V> toCompletableFuture(
+      final Executor exec,
+      final Callable<V> callable) {
+
+    Objects.requireNonNull(exec, "exec");
+    Objects.requireNonNull(callable, "callable");
+
+    final CompletableFuture<V> cf = new CompletableFuture<>();
+
+    try {
+      exec.execute(() -> {
+        try {
+          cf.complete(callable.call());
+        } catch (Throwable t) {
+          cf.completeExceptionally(t);
+        }
+      });
+    } catch (Throwable t) {
+      cf.completeExceptionally(t);
+    }
+
+    return cf;
+  }
+
+  /**
+   * Adapt a plain JDK {@link Future} to an async.java {@link Asyncc.AsyncTask}.
+   *
+   * <p>The blocking wait happens on {@code exec}. This makes the adapter safe to use at an
+   * async.java boundary without pinning the caller thread; for highly concurrent blocking waits,
+   * prefer a virtual-thread executor from {@link AsyncLoom#newVirtualThreadPerTaskExecutor()}.
+   *
+   * @param <V> value type produced by the future
+   * @param exec executor used for the blocking {@code Future#get()} wait
+   * @param future legacy/plain JDK future to adapt
+   * @return an async.java task suitable for callback combinators
+   * @since 0.2.10
+   */
+  public static <V> Asyncc.AsyncTask<V, Throwable> fromFuture(
+      final Executor exec,
+      final Future<? extends V> future) {
+
+    return c -> toCompletableFuture(exec, future).whenComplete((value, err) -> {
+      if (err != null) {
+        c.fail(err);
+      } else {
+        c.success(value);
+      }
+    });
+  }
+
+  /**
    * Adapt a synchronous (possibly blocking) {@link Callable} to an async.java task by
    * dispatching it onto the provided executor.
    *
@@ -195,11 +322,11 @@ public final class WrapFuture {
       final Executor exec,
       final Callable<V> callable) {
 
-    return c -> exec.execute(() -> {
-      try {
-        c.success(callable.call());
-      } catch (Throwable t) {
-        c.fail(t);
+    return c -> toCompletableFuture(exec, callable).whenComplete((value, err) -> {
+      if (err != null) {
+        c.fail(err);
+      } else {
+        c.success(value);
       }
     });
   }

--- a/src/main/java/org/ores/async/WrapFuture.java
+++ b/src/main/java/org/ores/async/WrapFuture.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Bridge between async.java's error-first callback shape and the JDK's promise primitive
@@ -23,6 +24,9 @@ import java.util.function.Consumer;
  *   <li>{@link #fromStage(CompletionStage)} — {@code CompletionStage} → async.java
  *       {@link Asyncc.AsyncTask}. Useful when consuming a third-party promise-returning API
  *       (a JDBC async driver, an HTTP client) inside an async.java combinator.</li>
+ *   <li>{@link #fromStage(Supplier)} — lazy {@code CompletionStage} supplier → async.java
+ *       task. Use this with {@code Series} / {@code ParallelLimit} when the stage should not be
+ *       created until the combinator actually starts that task.</li>
  *   <li>{@link #fromCallable(Executor, Callable)} — wrap a sync, possibly-blocking
  *       {@link Callable} as an async.java task, dispatching it onto the provided executor.</li>
  *   <li>{@link #fromFuture(Executor, Future)} — wrap a plain JDK {@link Future} as an async.java
@@ -176,6 +180,8 @@ public final class WrapFuture {
   public static <V> Asyncc.AsyncTask<V, Throwable> fromStage(
       final CompletionStage<V> stage) {
 
+    Objects.requireNonNull(stage, "stage");
+
     return c -> stage.whenComplete((value, err) -> {
       if (err != null) {
         c.fail(err);
@@ -183,6 +189,53 @@ public final class WrapFuture {
         c.success(value);
       }
     });
+  }
+
+  /**
+   * Adapt a lazy {@link CompletionStage} supplier to an async.java {@link Asyncc.AsyncTask}.
+   *
+   * <p>This is the supplier-shaped sibling of {@link #fromStage(CompletionStage)}. The supplier
+   * is invoked only when the combinator starts this task, which preserves async.java scheduling
+   * semantics for {@code Series}, {@code ParallelLimit}, {@code RaceLimit}, and other bounded or
+   * sequential combinators.
+   *
+   * <pre>
+   *   Asyncc.Series(List.of(
+   *       WrapFuture.fromStage(() -&gt; client.validateAsync(req)),
+   *       WrapFuture.fromStage(() -&gt; client.persistAsync(req))
+   *   ), finalCallback);
+   * </pre>
+   *
+   * <p>If the supplier throws before returning a stage, the task fails the callback with that
+   * throwable. If it returns {@code null}, the task fails with {@link NullPointerException}.
+   *
+   * @param <V> value type produced by the stage
+   * @param stageSupplier supplier invoked when the async.java task starts
+   * @return an async.java task suitable for callback combinators
+   * @since 0.2.10
+   */
+  public static <V> Asyncc.AsyncTask<V, Throwable> fromStage(
+      final Supplier<? extends CompletionStage<V>> stageSupplier) {
+
+    Objects.requireNonNull(stageSupplier, "stageSupplier");
+
+    return c -> {
+      final CompletionStage<V> stage;
+      try {
+        stage = Objects.requireNonNull(stageSupplier.get(), "stageSupplier.get()");
+      } catch (Throwable t) {
+        c.fail(t);
+        return;
+      }
+
+      stage.whenComplete((value, err) -> {
+        if (err != null) {
+          c.fail(err);
+        } else {
+          c.success(value);
+        }
+      });
+    };
   }
 
   /**

--- a/src/main/java/org/ores/async/package-info.java
+++ b/src/main/java/org/ores/async/package-info.java
@@ -122,6 +122,10 @@
  * {@link org.ores.async.WrapFuture#fromFuture(java.util.concurrent.Executor, java.util.concurrent.Future)}
  * or {@link org.ores.async.AsyncFut#ParallelFutures(java.util.concurrent.Executor, java.util.List)}.
  * async.java calls {@code Future.get()} inside the adapter on the executor you provide.
+ * For promise-returning APIs, use {@link org.ores.async.WrapFuture#fromStage(java.util.concurrent.CompletionStage)}
+ * for already-started work and {@link org.ores.async.WrapFuture#fromStage(java.util.function.Supplier)}
+ * when {@code Series}, {@code ParallelLimit}, or another bounded combinator should decide when
+ * the stage is created.
  *
  * <h3>Concurrency contract</h3>
  *

--- a/src/main/java/org/ores/async/package-info.java
+++ b/src/main/java/org/ores/async/package-info.java
@@ -125,7 +125,9 @@
  * For promise-returning APIs, use {@link org.ores.async.WrapFuture#fromStage(java.util.concurrent.CompletionStage)}
  * for already-started work and {@link org.ores.async.WrapFuture#fromStage(java.util.function.Supplier)}
  * when {@code Series}, {@code ParallelLimit}, or another bounded combinator should decide when
- * the stage is created.
+ * the stage is created. Promise-returning collection helpers such as
+ * {@link org.ores.async.AsyncFut#ConcatLimit(int, java.lang.Iterable, java.util.function.Function)}
+ * preserve async.java's bounded fan-out while returning {@link java.util.concurrent.CompletableFuture}.
  *
  * <h3>Concurrency contract</h3>
  *

--- a/src/main/java/org/ores/async/package-info.java
+++ b/src/main/java/org/ores/async/package-info.java
@@ -98,17 +98,30 @@
  *
  * <h3>Project Loom</h3>
  *
- * <p>async.java does not own a thread pool. Pass a virtual-thread executor and every fan-out
- * spawns on a virtual thread:
+ * <p>async.java's default callback combinators do not own a thread pool: tasks run on whichever
+ * thread invokes the continuation. For blocking work on Java 21+, use {@link org.ores.async.AsyncLoom}
+ * to run {@link java.util.concurrent.Callable} tasks on virtual threads while preserving the
+ * same orchestration semantics:
  *
  * <pre>
- *   var vt = Executors.newVirtualThreadPerTaskExecutor();
- *   NeoQueue.setExecutor(vt);                 // optional: NeoQueue callbacks via VTs
- *   // Tasks submit directly to `vt` themselves.
+ *   CompletableFuture&lt;List&lt;User&gt;&gt; users = AsyncLoom.ParallelBlocking(List.of(
+ *       () -&gt; jdbc.fetchUser("a"),
+ *       () -&gt; jdbc.fetchUser("b")
+ *   ));
+ *
+ *   Asyncc.SeriesBlocking(List.of(
+ *       () -&gt; migrateStep1(),
+ *       () -&gt; migrateStep2()
+ *   ), (err, results) -&gt; {
+ *       if (err != null) { rollback(err); return; }
+ *       commit(results);
+ *   });
  * </pre>
  *
- * <p>On JDK 21+, virtual-thread spawn is ~250 ns and blocking I/O inside a task is a continuation
- * park (not a kernel thread block). Per-call coordination overhead stays under 50 &micro;s.
+ * <p>For legacy APIs that return plain {@link java.util.concurrent.Future}, use
+ * {@link org.ores.async.WrapFuture#fromFuture(java.util.concurrent.Executor, java.util.concurrent.Future)}
+ * or {@link org.ores.async.AsyncFut#ParallelFutures(java.util.concurrent.Executor, java.util.List)}.
+ * async.java calls {@code Future.get()} inside the adapter on the executor you provide.
  *
  * <h3>Concurrency contract</h3>
  *
@@ -128,6 +141,9 @@
  * <a href="https://github.com/async-java/async.java/issues">github.com/async-java/async.java/issues</a>.
  *
  * @see org.ores.async.Asyncc
+ * @see org.ores.async.AsyncFut
+ * @see org.ores.async.AsyncLoom
+ * @see org.ores.async.WrapFuture
  * @see org.ores.async.NeoQueue
  * @see org.ores.async.NeoLock
  */

--- a/src/test/java/examples/AsyncFutConcatExample.java
+++ b/src/test/java/examples/AsyncFutConcatExample.java
@@ -1,0 +1,34 @@
+package examples;
+
+import org.ores.async.AsyncFut;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Compile-checked examples for promise-returning concat helpers.
+ */
+public final class AsyncFutConcatExample {
+
+  private AsyncFutConcatExample() {}
+
+  public static CompletableFuture<List<String>> fanOutThenFlatten(final OrdersClient client) {
+    return AsyncFut.ConcatLimit(
+        4,
+        List.of("alice", "bob", "carol"),
+        client::ordersForUser);
+  }
+
+  public static CompletableFuture<List<String>> sequentialFlatten(final OrdersClient client) {
+    return AsyncFut.ConcatSeries(
+        List.of("validate", "persist"),
+        client::stepOutputs);
+  }
+
+  public interface OrdersClient {
+    CompletionStage<List<String>> ordersForUser(String userId);
+
+    CompletionStage<List<String>> stepOutputs(String step);
+  }
+}

--- a/src/test/java/examples/CallbackBlockingExample.java
+++ b/src/test/java/examples/CallbackBlockingExample.java
@@ -1,0 +1,54 @@
+package examples;
+
+import org.ores.async.Asyncc;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Compile-checked examples for callback-style virtual-thread blocking helpers.
+ */
+public final class CallbackBlockingExample {
+
+  private CallbackBlockingExample() {}
+
+  public static CompletableFuture<List<String>> seriesBlockingCallback() {
+    final CompletableFuture<List<String>> result = new CompletableFuture<>();
+    Asyncc.SeriesBlocking(List.of(
+        (Callable<String>) () -> blockingStep("validate"),
+        () -> blockingStep("write"),
+        () -> blockingStep("publish")),
+        (err, values) -> {
+          if (err != null) {
+            result.completeExceptionally(err);
+          } else {
+            result.complete(values);
+          }
+        });
+    return result;
+  }
+
+  public static CompletableFuture<String> raceBlockingCallback() {
+    final CompletableFuture<String> result = new CompletableFuture<>();
+    Asyncc.RaceBlocking(List.of(
+        (Callable<String>) () -> {
+          Thread.sleep(25);
+          return blockingStep("primary");
+        },
+        () -> blockingStep("replica")),
+        (err, value) -> {
+          if (err != null) {
+            result.completeExceptionally(err);
+          } else {
+            result.complete(value);
+          }
+        });
+    return result;
+  }
+
+  private static String blockingStep(final String name) throws InterruptedException {
+    Thread.sleep(10);
+    return "done-" + name;
+  }
+}

--- a/src/test/java/examples/CompletionStageInteropExample.java
+++ b/src/test/java/examples/CompletionStageInteropExample.java
@@ -1,0 +1,30 @@
+package examples;
+
+import org.ores.async.Asyncc;
+import org.ores.async.WrapFuture;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Compile-checked examples for bridging promise-returning APIs into callback combinators.
+ */
+public final class CompletionStageInteropExample {
+
+  private CompletionStageInteropExample() {}
+
+  public static CompletableFuture<List<String>> lazySeriesStages(final StageClient client) {
+    return WrapFuture.toFuture(c ->
+        Asyncc.<String, Throwable>Series(List.of(
+            WrapFuture.fromStage(client::validateAsync),
+            WrapFuture.fromStage(client::persistAsync)
+        ), c));
+  }
+
+  public interface StageClient {
+    CompletionStage<String> validateAsync();
+
+    CompletionStage<String> persistAsync();
+  }
+}

--- a/src/test/java/examples/FutureInteropExample.java
+++ b/src/test/java/examples/FutureInteropExample.java
@@ -1,0 +1,57 @@
+package examples;
+
+import org.ores.async.AsyncFut;
+import org.ores.async.AsyncLoom;
+import org.ores.async.Asyncc;
+import org.ores.async.WrapFuture;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Compile-checked examples for adapting plain JDK {@link Future} values.
+ */
+public final class FutureInteropExample {
+
+  private FutureInteropExample() {}
+
+  /**
+   * Use a virtual-thread wait executor on JDK 21+, with a cached platform-thread fallback for
+   * older JDKs. Callers own the returned executor and should shut it down.
+   */
+  public static ExecutorService defaultWaitExecutor() {
+    if (AsyncLoom.isSupported()) {
+      return AsyncLoom.newVirtualThreadPerTaskExecutor();
+    }
+    return Executors.newCachedThreadPool();
+  }
+
+  public static CompletableFuture<List<String>> parallelFutures(
+      final ExecutorService legacyPool,
+      final ExecutorService waiters) {
+
+    final List<Future<String>> futures = List.of(
+        legacyPool.submit(() -> lookup("primary")),
+        legacyPool.submit(() -> lookup("secondary")));
+
+    return AsyncFut.ParallelFutures(waiters, futures);
+  }
+
+  public static CompletableFuture<List<String>> callbackBridge(
+      final ExecutorService legacyPool,
+      final ExecutorService waiters) {
+
+    return WrapFuture.toFuture(c ->
+        Asyncc.Parallel(List.of(
+            WrapFuture.fromFuture(waiters, legacyPool.submit(() -> lookup("cache"))),
+            WrapFuture.fromFuture(waiters, legacyPool.submit(() -> lookup("database")))),
+            c));
+  }
+
+  private static String lookup(final String source) {
+    return "value-from-" + source;
+  }
+}

--- a/src/test/java/examples/LoomBlockingExample.java
+++ b/src/test/java/examples/LoomBlockingExample.java
@@ -1,0 +1,57 @@
+package examples;
+
+import org.ores.async.AsyncLoom;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Compile-checked examples for Java 21+ virtual-thread blocking helpers.
+ */
+public final class LoomBlockingExample {
+
+  private LoomBlockingExample() {}
+
+  public static CompletableFuture<List<String>> parallelBlocking() {
+    return AsyncLoom.ParallelBlocking(List.of(
+        () -> blockingRead("profile"),
+        () -> blockingRead("permissions")));
+  }
+
+  public static CompletableFuture<List<String>> seriesBlocking() {
+    return AsyncLoom.SeriesBlocking(List.of(
+        () -> blockingRead("validate"),
+        () -> blockingRead("persist"),
+        () -> blockingRead("notify")));
+  }
+
+  public static CompletableFuture<String> raceBlocking() {
+    return AsyncLoom.RaceBlocking(List.of(
+        () -> {
+          Thread.sleep(25);
+          return blockingRead("primary");
+        },
+        () -> blockingRead("replica")));
+  }
+
+  public static CompletableFuture<Integer> reduceBlocking() {
+    return AsyncLoom.ReduceBlocking(
+        List.of("a", "bb", "ccc"),
+        0,
+        (acc, value) -> acc + value.length());
+  }
+
+  public static CompletableFuture<List<Path>> concatBlocking() {
+    return AsyncLoom.ConcatBlocking(
+        List.of("tenant-a", "tenant-b"),
+        tenant -> List.of(
+            Path.of("/data", tenant, "events.log"),
+            Path.of("/data", tenant, "metrics.log")));
+  }
+
+  private static String blockingRead(final String key) throws InterruptedException {
+    Thread.sleep(10);
+    return "read-" + key;
+  }
+}

--- a/src/test/java/general/AsyncFutTest.java
+++ b/src/test/java/general/AsyncFutTest.java
@@ -156,6 +156,86 @@ public class AsyncFutTest {
     }
   }
 
+  // ---------------- Concat -----------------------------------------------
+
+  @Test(timeout = TIMEOUT)
+  public void concat_flattens_mapper_collections_preserving_input_order() throws Exception {
+    final CompletableFuture<List<Integer>> fut = AsyncFut.Concat(
+        List.of(1, 2, 3),
+        n -> CompletableFuture.completedFuture(List.of(n, n * 10)));
+
+    assertEquals(List.of(1, 10, 2, 20, 3, 30), fut.get(2, TimeUnit.SECONDS));
+  }
+
+  @Test(timeout = TIMEOUT)
+  public void concatSeries_runs_mapper_sequentially() throws Exception {
+    final AtomicInteger order = new AtomicInteger();
+
+    final CompletableFuture<List<String>> fut = AsyncFut.ConcatSeries(
+        List.of("validate", "persist", "notify"),
+        step -> {
+          final int expected = switch (step) {
+            case "validate" -> 0;
+            case "persist" -> 1;
+            case "notify" -> 2;
+            default -> throw new AssertionError(step);
+          };
+          assertEquals(expected, order.getAndIncrement());
+          return CompletableFuture.completedFuture(List.of(step));
+        });
+
+    assertEquals(List.of("validate", "persist", "notify"), fut.get(2, TimeUnit.SECONDS));
+    assertEquals(3, order.get());
+  }
+
+  @Test(timeout = TIMEOUT)
+  public void concatLimit_enforces_concurrency_cap() throws Exception {
+    final ExecutorService exec = Executors.newFixedThreadPool(8);
+    try {
+      final AtomicInteger inFlight = new AtomicInteger();
+      final AtomicInteger maxInFlight = new AtomicInteger();
+
+      final CompletableFuture<List<Integer>> fut = AsyncFut.ConcatLimit(
+          2,
+          List.of(1, 2, 3, 4, 5, 6),
+          n -> CompletableFuture.supplyAsync(() -> {
+            final int now = inFlight.incrementAndGet();
+            maxInFlight.accumulateAndGet(now, Math::max);
+            try { Thread.sleep(10); } catch (InterruptedException ie) { /* */ }
+            inFlight.decrementAndGet();
+            return List.of(n, n * 10);
+          }, exec));
+
+      assertEquals(List.of(1, 10, 2, 20, 3, 30, 4, 40, 5, 50, 6, 60),
+          fut.get(5, TimeUnit.SECONDS));
+      assertTrue(
+          "max in-flight (" + maxInFlight.get() + ") must not exceed limit 2",
+          maxInFlight.get() <= 2);
+    } finally {
+      exec.shutdown();
+      exec.awaitTermination(2, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test(timeout = TIMEOUT)
+  public void concat_short_circuits_on_mapper_failure() throws Exception {
+    final CompletableFuture<List<Integer>> fut = AsyncFut.Concat(
+        List.of(1, 2, 3),
+        n -> {
+          if (n == 2) {
+            return CompletableFuture.failedFuture(new IllegalStateException("concat-boom"));
+          }
+          return CompletableFuture.completedFuture(List.of(n));
+        });
+
+    try {
+      fut.get(2, TimeUnit.SECONDS);
+      fail("expected ExecutionException");
+    } catch (ExecutionException ee) {
+      assertTrue(ee.getCause().getMessage().contains("concat-boom"));
+    }
+  }
+
   // ---------------- Reduce -----------------------------------------------
 
   @Test(timeout = TIMEOUT)

--- a/src/test/java/general/CounterLimitRaceTest.java
+++ b/src/test/java/general/CounterLimitRaceTest.java
@@ -49,9 +49,9 @@ public class CounterLimitRaceTest {
   @Test(timeout = 60_000)
   public void parallelDoesNotLoseFinalCallbackUnderRapidFire() throws Exception {
 
-    // The library targets JDK 11; only run this test when a JDK 21+ runtime gives us
+    // The library targets JDK 17; only run this test when a JDK 21+ runtime gives us
     // virtual threads. Reflection because `Executors.newVirtualThreadPerTaskExecutor()` is
-    // not available in the JDK 11 baseline `release` the maven-compiler-plugin enforces.
+    // not available in the JDK 17 baseline `release` the maven-compiler-plugin enforces.
     final ExecutorService vt = newVirtualThreadPerTaskExecutorOrSkip();
     final int iterations = 500;
     try {

--- a/src/test/java/general/FutureAndLoomInteropTest.java
+++ b/src/test/java/general/FutureAndLoomInteropTest.java
@@ -1,0 +1,297 @@
+package general;
+
+import org.junit.Assume;
+import org.junit.Test;
+import org.ores.async.AsyncFut;
+import org.ores.async.AsyncLoom;
+import org.ores.async.Asyncc;
+import org.ores.async.WrapFuture;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Pins interop with plain JDK Futures and Java 21 virtual threads.
+ */
+public class FutureAndLoomInteropTest {
+
+  @Test(timeout = 10_000)
+  public void toCompletableFuture_calls_future_get_inside_the_library() throws Exception {
+    final AtomicInteger getCalls = new AtomicInteger();
+    final Future<String> future = new Future<>() {
+      @Override public boolean cancel(boolean mayInterruptIfRunning) { return false; }
+      @Override public boolean isCancelled() { return false; }
+      @Override public boolean isDone() { return true; }
+      @Override public String get() { getCalls.incrementAndGet(); return "ok"; }
+      @Override public String get(long timeout, TimeUnit unit) { getCalls.incrementAndGet(); return "ok"; }
+    };
+
+    final ExecutorService waitExec = Executors.newSingleThreadExecutor();
+    try {
+      final CompletableFuture<String> cf = WrapFuture.toCompletableFuture(waitExec, future);
+      assertEquals("ok", cf.get(2, TimeUnit.SECONDS));
+      assertEquals(1, getCalls.get());
+    } finally {
+      waitExec.shutdownNow();
+    }
+  }
+
+  @Test(timeout = 10_000)
+  public void toCompletableFuture_unwraps_execution_exception_cause() throws Exception {
+    final IllegalStateException boom = new IllegalStateException("boom");
+    final FutureTask<String> future = new FutureTask<>(() -> {
+      throw boom;
+    });
+    new Thread(future, "future-interop-failing-work").start();
+
+    final ExecutorService waitExec = Executors.newSingleThreadExecutor();
+    try {
+      final CompletableFuture<String> cf = WrapFuture.toCompletableFuture(waitExec, future);
+      try {
+        cf.get(2, TimeUnit.SECONDS);
+        fail("expected ExecutionException");
+      } catch (ExecutionException ee) {
+        assertSame(boom, ee.getCause());
+      }
+    } finally {
+      waitExec.shutdownNow();
+    }
+  }
+
+  @Test(timeout = 10_000)
+  public void cancelling_completable_future_cancels_underlying_future() throws Exception {
+    final FutureTask<String> future = new FutureTask<>(() -> {
+      Thread.sleep(5_000);
+      return "late";
+    });
+    final Thread worker = new Thread(future, "future-interop-cancel-work");
+    worker.start();
+
+    final ExecutorService waitExec = Executors.newSingleThreadExecutor();
+    try {
+      final CompletableFuture<String> cf = WrapFuture.toCompletableFuture(waitExec, future);
+      assertTrue(cf.cancel(true));
+      assertTrue(future.isCancelled());
+      worker.join(1_000);
+    } finally {
+      waitExec.shutdownNow();
+    }
+  }
+
+  @Test(timeout = 10_000)
+  public void fromFuture_drops_plain_future_into_callback_combinator() throws Exception {
+    final ExecutorService workExec = Executors.newFixedThreadPool(2);
+    final ExecutorService waitExec = Executors.newFixedThreadPool(2);
+    try {
+      final CompletableFuture<List<String>> cf = WrapFuture.toFuture(c ->
+          Asyncc.<String, Throwable>Parallel(List.of(
+              WrapFuture.fromFuture(waitExec, workExec.submit(() -> "alpha")),
+              WrapFuture.fromFuture(waitExec, workExec.submit(() -> "beta"))
+          ), c)
+      );
+
+      assertEquals(List.of("alpha", "beta"), cf.get(2, TimeUnit.SECONDS));
+    } finally {
+      waitExec.shutdownNow();
+      workExec.shutdownNow();
+    }
+  }
+
+  @Test(timeout = 10_000)
+  public void parallelFutures_collects_plain_future_results_in_order() throws Exception {
+    final ExecutorService workExec = Executors.newFixedThreadPool(3);
+    final ExecutorService waitExec = Executors.newCachedThreadPool();
+    try {
+      final List<Future<Integer>> futures = List.of(
+          workExec.submit(() -> {
+            Thread.sleep(20);
+            return 1;
+          }),
+          workExec.submit(() -> 2),
+          workExec.submit(() -> 3)
+      );
+
+      assertEquals(
+          List.of(1, 2, 3),
+          AsyncFut.ParallelFutures(waitExec, futures).get(2, TimeUnit.SECONDS));
+    } finally {
+      waitExec.shutdownNow();
+      workExec.shutdownNow();
+    }
+  }
+
+  @Test(timeout = 10_000)
+  public void raceFutures_returns_first_plain_future_result() throws Exception {
+    final ExecutorService workExec = Executors.newFixedThreadPool(2);
+    final ExecutorService waitExec = Executors.newCachedThreadPool();
+    try {
+      final List<Future<String>> futures = List.of(
+          workExec.submit(() -> {
+            Thread.sleep(200);
+            return "slow";
+          }),
+          workExec.submit(() -> "fast")
+      );
+
+      assertEquals("fast", AsyncFut.RaceFutures(waitExec, futures).get(2, TimeUnit.SECONDS));
+    } finally {
+      waitExec.shutdownNow();
+      workExec.shutdownNow();
+    }
+  }
+
+  @Test(timeout = 10_000)
+  public void asyncLoom_detection_is_safe_on_java17() {
+    if (!AsyncLoom.isSupported()) {
+      assertFalse(AsyncLoom.isVirtualThread());
+      try {
+        AsyncLoom.newVirtualThreadPerTaskExecutor();
+        fail("expected UnsupportedOperationException");
+      } catch (UnsupportedOperationException expected) {
+        assertTrue(expected.getMessage().contains("JDK 21"));
+      }
+    }
+  }
+
+  @Test(timeout = 10_000)
+  public void asyncLoom_supply_runs_callable_on_virtual_thread_when_available() throws Exception {
+    Assume.assumeTrue("requires JDK 21+ virtual threads", AsyncLoom.isSupported());
+
+    final CompletableFuture<Boolean> cf = AsyncLoom.supply(AsyncLoom::isVirtualThread);
+    assertTrue(cf.get(2, TimeUnit.SECONDS));
+  }
+
+  @Test(timeout = 10_000)
+  public void asyncLoom_parallelBlocking_runs_tasks_on_virtual_threads_when_available() throws Exception {
+    Assume.assumeTrue("requires JDK 21+ virtual threads", AsyncLoom.isSupported());
+
+    final List<Callable<Boolean>> tasks = List.of(
+        AsyncLoom::isVirtualThread,
+        AsyncLoom::isVirtualThread,
+        AsyncLoom::isVirtualThread
+    );
+
+    assertEquals(
+        List.of(true, true, true),
+        AsyncLoom.ParallelBlocking(tasks).get(2, TimeUnit.SECONDS));
+  }
+
+  @Test(timeout = 10_000)
+  public void asyncc_blocking_wrappers_report_unsupported_on_java17() throws Exception {
+    Assume.assumeFalse("only meaningful on Java 17/unsupported runtimes", AsyncLoom.isSupported());
+
+    final CompletableFuture<Throwable> err = new CompletableFuture<>();
+    Asyncc.SeriesBlocking(List.of(() -> "x"), (e, results) -> err.complete(e));
+
+    assertTrue(err.get(2, TimeUnit.SECONDS) instanceof UnsupportedOperationException);
+  }
+
+  @Test(timeout = 10_000)
+  public void asyncLoom_seriesBlocking_runs_each_step_on_virtual_thread_when_available() throws Exception {
+    Assume.assumeTrue("requires JDK 21+ virtual threads", AsyncLoom.isSupported());
+
+    final AtomicInteger order = new AtomicInteger();
+    final List<Callable<String>> tasks = List.of(
+        () -> {
+          assertTrue(AsyncLoom.isVirtualThread());
+          assertEquals(0, order.getAndIncrement());
+          return "a";
+        },
+        () -> {
+          assertTrue(AsyncLoom.isVirtualThread());
+          assertEquals(1, order.getAndIncrement());
+          return "b";
+        }
+    );
+
+    assertEquals(List.of("a", "b"), AsyncLoom.SeriesBlocking(tasks).get(2, TimeUnit.SECONDS));
+  }
+
+  @Test(timeout = 10_000)
+  public void asyncLoom_reduceBlocking_runs_reducer_on_virtual_thread_when_available() throws Exception {
+    Assume.assumeTrue("requires JDK 21+ virtual threads", AsyncLoom.isSupported());
+
+    final Integer sum = AsyncLoom.ReduceBlocking(
+        List.of(1, 2, 3),
+        0,
+        (acc, item) -> {
+          assertTrue(AsyncLoom.isVirtualThread());
+          return acc + item;
+        }).get(2, TimeUnit.SECONDS);
+
+    assertEquals(Integer.valueOf(6), sum);
+  }
+
+  @Test(timeout = 10_000)
+  public void asyncLoom_concatBlocking_runs_mapper_on_virtual_threads_when_available() throws Exception {
+    Assume.assumeTrue("requires JDK 21+ virtual threads", AsyncLoom.isSupported());
+
+    final List<Integer> result = AsyncLoom.ConcatBlocking(
+        List.of(1, 2, 3),
+        item -> {
+          assertTrue(AsyncLoom.isVirtualThread());
+          return List.of(item, item * 10);
+        }).get(2, TimeUnit.SECONDS);
+
+    assertEquals(List.of(1, 10, 2, 20, 3, 30), result);
+  }
+
+  @Test(timeout = 10_000)
+  public void asyncc_raceBlocking_races_callables_on_virtual_threads_when_available() throws Exception {
+    Assume.assumeTrue("requires JDK 21+ virtual threads", AsyncLoom.isSupported());
+
+    final CompletableFuture<String> result = new CompletableFuture<>();
+    Asyncc.<String>RaceBlocking(List.<Callable<String>>of(
+        () -> {
+          assertTrue(AsyncLoom.isVirtualThread());
+          Thread.sleep(200);
+          return "slow";
+        },
+        () -> {
+          assertTrue(AsyncLoom.isVirtualThread());
+          return "fast";
+        }
+    ), (err, value) -> {
+      if (err != null) {
+        result.completeExceptionally(err);
+      } else {
+        result.complete(value);
+      }
+    });
+
+    assertEquals("fast", result.get(2, TimeUnit.SECONDS));
+  }
+
+  @Test(timeout = 10_000)
+  public void asyncc_concatBlocking_reports_flattened_callback_result_when_available() throws Exception {
+    Assume.assumeTrue("requires JDK 21+ virtual threads", AsyncLoom.isSupported());
+
+    final CompletableFuture<List<Integer>> result = new CompletableFuture<>();
+    Asyncc.ConcatBlocking(List.of(1, 2), item -> {
+      assertTrue(AsyncLoom.isVirtualThread());
+      return List.of(item, item + 10);
+    }, (err, value) -> {
+      if (err != null) {
+        result.completeExceptionally(err);
+      } else {
+        result.complete(value);
+      }
+    });
+
+    assertEquals(List.of(1, 11, 2, 12), result.get(2, TimeUnit.SECONDS));
+  }
+}

--- a/src/test/java/general/FutureAndLoomInteropTest.java
+++ b/src/test/java/general/FutureAndLoomInteropTest.java
@@ -112,6 +112,63 @@ public class FutureAndLoomInteropTest {
   }
 
   @Test(timeout = 10_000)
+  public void fromStage_supplier_is_lazy_until_callback_task_runs() throws Exception {
+    final AtomicInteger starts = new AtomicInteger();
+
+    final Asyncc.AsyncTask<String, Throwable> task = WrapFuture.fromStage(() -> {
+      starts.incrementAndGet();
+      return CompletableFuture.completedFuture("lazy");
+    });
+
+    assertEquals(0, starts.get());
+
+    final CompletableFuture<String> result = new CompletableFuture<>();
+    task.run((err, value) -> {
+      if (err != null) {
+        result.completeExceptionally(err);
+      } else {
+        result.complete(value);
+      }
+    });
+
+    assertEquals("lazy", result.get(2, TimeUnit.SECONDS));
+    assertEquals(1, starts.get());
+  }
+
+  @Test(timeout = 10_000)
+  public void fromStage_supplier_preserves_series_ordering() throws Exception {
+    final AtomicInteger order = new AtomicInteger();
+
+    final CompletableFuture<List<String>> cf = WrapFuture.toFuture(c ->
+        Asyncc.<String, Throwable>Series(List.of(
+            WrapFuture.fromStage(() -> {
+              assertEquals(0, order.getAndIncrement());
+              return CompletableFuture.completedFuture("validate");
+            }),
+            WrapFuture.fromStage(() -> {
+              assertEquals(1, order.getAndIncrement());
+              return CompletableFuture.completedFuture("persist");
+            })
+        ), c));
+
+    assertEquals(List.of("validate", "persist"), cf.get(2, TimeUnit.SECONDS));
+    assertEquals(2, order.get());
+  }
+
+  @Test(timeout = 10_000)
+  public void fromStage_supplier_reports_synchronous_throw() throws Exception {
+    final IllegalArgumentException boom = new IllegalArgumentException("stage supplier failed");
+    final Asyncc.AsyncTask<String, Throwable> task = WrapFuture.fromStage(() -> {
+      throw boom;
+    });
+
+    final CompletableFuture<Throwable> error = new CompletableFuture<>();
+    task.run((err, value) -> error.complete(err));
+
+    assertSame(boom, error.get(2, TimeUnit.SECONDS));
+  }
+
+  @Test(timeout = 10_000)
   public void parallelFutures_collects_plain_future_results_in_order() throws Exception {
     final ExecutorService workExec = Executors.newFixedThreadPool(3);
     final ExecutorService waitExec = Executors.newCachedThreadPool();

--- a/src/test/java/general/MisuseTest.java
+++ b/src/test/java/general/MisuseTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.fail;
  * production downstream consumers were observed to hit (or could plausibly hit).
  *
  * <p>None of these depend on JDK 21 — they exercise the core combinator contracts using
- * plain threads, so they run on JDK 11+ as well.
+ * plain threads, so they run on the JDK 17 baseline as well.
  */
 public class MisuseTest {
 


### PR DESCRIPTION
## Summary
- add plain JDK Future adapters that call Future.get() inside the library and propagate cancellation
- add AsyncLoom virtual-thread helpers plus callback-style Asyncc.*Blocking wrappers
- add Future/Loom tests, compile-checked examples, expanded README/Javadocs, and a 0.2.10 changelog entry
- refresh Maven/JitPack/release tooling for Central Portal, GitHub Packages, sources, Javadocs, and credential hygiene

## Validation
- JDK 17: mvn -B -Dgpg.skip=true -Dmaven.javadoc.skip=true test => 207 tests, 0 failures, 9 expected skips
- JDK 21: mvn -B -Dgpg.skip=true -Dmaven.javadoc.skip=true test => 207 tests, 0 failures, 1 expected skip
- mvn -s settings.xml -B -P publish-artifacts,release -DskipTests -Dgpg.skip=true verify
- local file-backed GitHub Packages deploy dry run produced jar, pom, sources, javadocs, checksums, and metadata
- workflow YAML parsed successfully

## Release note
Do not push the v0.2.10 tag until Central/GPG secrets are configured. Repo-level secret listing is currently empty, and org-level secrets were not visible to the active token.
